### PR TITLE
Handle Early Ending of Judging

### DIFF
--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -8,7 +8,6 @@ export async function getRequest<T>(path: string): Promise<FetchResponse<T>> {
             credentials: 'include',
         };
         const response = await fetch(`${BACKEND_URL}${path}`, options);
-        if (!response.ok) throw new Error(response.statusText);
 
         const data = await response.json();
         return { status: response.status, error: data.error ? data.error : '', data };
@@ -31,7 +30,6 @@ export async function postRequest<T>(
             body: body ? JSON.stringify(body) : null,
         };
         const response = await fetch(`${BACKEND_URL}${path}`, options);
-        if (!response.ok) throw new Error(response.statusText);
 
         const data = await response.json();
         return { status: response.status, error: data.error ? data.error : '', data };
@@ -54,7 +52,6 @@ export async function putRequest<T>(
             body: body ? JSON.stringify(body) : null,
         };
         const response = await fetch(`${BACKEND_URL}${path}`, options);
-        if (!response.ok) throw new Error(response.statusText);
 
         const data = await response.json();
         return { status: response.status, error: data.error ? data.error : '', data };
@@ -67,7 +64,7 @@ export async function putRequest<T>(
 
 export async function deleteRequest(
     path: string
-): Promise<FetchResponse<OkResponse>> {
+): Promise<FetchResponse<YesNoResponse>> {
     try {
         const options: RequestInit = {
             method: 'DELETE',
@@ -75,7 +72,6 @@ export async function deleteRequest(
             credentials: 'include',
         };
         const response = await fetch(`${BACKEND_URL}${path}`, options);
-        if (!response.ok) throw new Error(response.statusText);
 
         const data = await response.json();
         return { status: response.status, error: data.error ? data.error : '', data };

--- a/client/src/components/admin/AdminToggleSwitch.tsx
+++ b/client/src/components/admin/AdminToggleSwitch.tsx
@@ -5,7 +5,7 @@ const AdminToggleSwitch = (props: {
     setState: React.Dispatch<React.SetStateAction<boolean>>;
 }) => {
     return (
-        <div className="w-full flex flex-row items-center justify-center my-10">
+        <div className="w-full flex flex-row items-center justify-center">
             <div className="bg-primaryLight flex flex-row rounded-full relative">
                 <div
                     className={`absolute top-0 left-0 w-44 h-16 transition-transform duration-300 ease-in-out ${

--- a/client/src/components/admin/tables/HidePopup.tsx
+++ b/client/src/components/admin/tables/HidePopup.tsx
@@ -23,7 +23,7 @@ const DeletePopup = ({ element, close }: DeletePopupProps) => {
 
     const hideElement = async () => {
         const resource = isProject(element) ? 'project' : 'judge';
-        const res = await postRequest<OkResponse>(`/${resource}/hide`, {id: element.id});
+        const res = await postRequest<YesNoResponse>(`/${resource}/hide`, {id: element.id});
         if (res.status === 200) {
             fetchStats();
             isProject(element) ? fetchProjects() : fetchJudges();

--- a/client/src/components/admin/tables/JudgeRow.tsx
+++ b/client/src/components/admin/tables/JudgeRow.tsx
@@ -43,7 +43,7 @@ const JudgeRow = ({ judge, idx, checked, handleCheckedChange }: JudgeRowProps) =
     };
 
     const hideJudge = async () => {
-        const res = await postRequest<OkResponse>(judge.active ? '/judge/hide' : '/judge/unhide', {id: judge.id});
+        const res = await postRequest<YesNoResponse>(judge.active ? '/judge/hide' : '/judge/unhide', {id: judge.id});
         if (res.status === 200) {
             alert(`Judge ${judge.active ? 'hidden' : 'un-hidden'} successfully!`);
             fetchJudges();

--- a/client/src/components/admin/tables/ProjectRow.tsx
+++ b/client/src/components/admin/tables/ProjectRow.tsx
@@ -54,7 +54,7 @@ const ProjectRow = ({ project, idx, checked, handleCheckedChange }: ProjectRowPr
     };
 
     const hideProject = async () => {
-        const res = await postRequest<OkResponse>(project.active ? '/project/hide' : '/project/unhide', {id: project.id});
+        const res = await postRequest<YesNoResponse>(project.active ? '/project/hide' : '/project/unhide', {id: project.id});
         if (res.status === 200) {
             alert(`Project ${project.active ? 'hidden' : 'un-hidden'} successfully!`);
             fetchProjects();

--- a/client/src/components/judge/Ratings.tsx
+++ b/client/src/components/judge/Ratings.tsx
@@ -54,11 +54,11 @@ const Ratings = (props: RatingsProps) => {
 
         // Score the current project
         const scoreRes = props.update
-            ? await putRequest<OkResponse>('/judge/score', {
+            ? await putRequest<YesNoResponse>('/judge/score', {
                 categories: scores,
                 project: props.project?.project_id,
             })
-            : await postRequest<OkResponse>('/judge/score', {
+            : await postRequest<YesNoResponse>('/judge/score', {
                 categories: scores,
                 initial: true,
             });

--- a/client/src/components/judge/popups/FlagPopup.tsx
+++ b/client/src/components/judge/popups/FlagPopup.tsx
@@ -66,7 +66,7 @@ const FlagPopup = (props: FlagPopupProps) => {
         }
 
         // Flag the current project
-        const flagRes = await postRequest<OkResponse>('/judge/skip', {
+        const flagRes = await postRequest<YesNoResponse>('/judge/skip', {
             reason: selected,
         });
         if (flagRes.status !== 200) {

--- a/client/src/data.json
+++ b/client/src/data.json
@@ -15,6 +15,10 @@
         "noProjects": {
             "title": "There are no projects to judge",
             "description": "You're early! There seems to be no projects currently in the system to judge. Please let an organizer know if this is unexpected."
+        },
+        "judgingEnded": {
+            "title": "Judging has been ended",
+            "description": "Judging has been ended by an admin. Please rank and submit what projects you have already seen."
         }
     },
     "flags": {

--- a/client/src/pages/admin/index.tsx
+++ b/client/src/pages/admin/index.tsx
@@ -51,12 +51,12 @@ const Admin = () => {
         checkSubmittedJudges();
 
         async function checkJudgingEnded() {
-            const judgingEndedRes = await getRequest<JudgingEnded>('/admin/end-judging')
+            const judgingEndedRes = await getRequest<YesNoResponse>('/check-judging-over')
             if (judgingEndedRes.status !== 200) {
                 errorAlert(judgingEndedRes);
                 return;
             }
-            setJudgingEnded(judgingEndedRes.data?.judging_ended as boolean);
+            setJudgingEnded(Boolean(judgingEndedRes.data?.yes_no));
         }
         checkJudgingEnded();
     }, []);

--- a/client/src/pages/admin/index.tsx
+++ b/client/src/pages/admin/index.tsx
@@ -48,26 +48,32 @@ const Admin = () => {
 
         }
         getNumJudges();
+        checkSubmittedJudges();
 
         async function checkJudgingEnded() {
-            // const judgingEndedRes = await getRequest<OkResponse>('/admin/end_judging')
-            setJudgingEnded(false)
+            const judgingEndedRes = await getRequest<JudgingEnded>('/admin/end-judging')
+            if (judgingEndedRes.status !== 200) {
+                errorAlert(judgingEndedRes);
+                return;
+            }
+            setJudgingEnded(judgingEndedRes.data?.judging_ended as boolean);
         }
         checkJudgingEnded();
     }, []);
 
     function endJudging() {
         let confirmed = window.confirm("Are you sure you want to end judging? This cannot be undone.\n" +
-            "Judges will not be able to request new projects to rank and must submit rankings.")
+            "Judges will not be able to request new projects to rank and must submit rankings.");
         if (confirmed) {
             endJudgingReq().then(success => {
                 if (success) {
                     alert("Judging has now been ended. Judges will be notified and made to submit their rankings. " +
-                        "Wait until all have submitted before recording final results.")
-                    setJudgingEnded(true)
+                        "Wait until all have submitted before recording final results.");
+                    setJudgingEnded(true);
                     checkSubmittedJudges();
                 } else {
-                    alert("Failed to end judging.")
+                    alert("Failed to end judging.");
+                    setJudgingEnded(false);
                 }
             })
         }
@@ -75,9 +81,8 @@ const Admin = () => {
 
     async function endJudgingReq() {
         console.log("Requesting server to end judging.")
-        // const endJudgingRes = await postRequest<OkResponse>('/admin/end_judging', null)
-        // lucatodo: pause and remove clock
-        return true
+        const endJudgingRes = await postRequest<OkResponse>('/admin/end-judging', null)
+        return endJudgingRes.status === 200;
     }
 
     async function checkSubmittedJudges() {

--- a/client/src/pages/admin/index.tsx
+++ b/client/src/pages/admin/index.tsx
@@ -95,7 +95,7 @@ const Admin = () => {
         if (justListRes.data){
             let numSubmitted = 0
             justListRes.data.forEach(j => {
-                if (j.current_rankings.length == 0) numSubmitted++
+                if (j.past_rankings.flat().length == j.seen) numSubmitted++
             })
             setSubmittedJudges(numSubmitted)
         }

--- a/client/src/pages/admin/index.tsx
+++ b/client/src/pages/admin/index.tsx
@@ -18,6 +18,7 @@ const Admin = () => {
     const [loading, setLoading] = useState(true);
     const [judgingEnded, setJudgingEnded] = useState(false);
     const [numJudges, setNumJudges] = useState(0);
+    const [submittedJudges, setSubmittedJudges] = useState(0);
 
     useEffect(() => {
         // Check if user logged in
@@ -64,6 +65,7 @@ const Admin = () => {
                     alert("Judging has now been ended. Judges will be notified and made to submit their rankings. " +
                         "Wait until all have submitted before recording final results.")
                     setJudgingEnded(true)
+                    checkSubmittedJudges();
                 } else {
                     alert("Failed to end judging.")
                 }
@@ -76,6 +78,22 @@ const Admin = () => {
         // const endJudgingRes = await postRequest<OkResponse>('/admin/end_judging', null)
         // lucatodo: pause and remove clock
         return true
+    }
+
+    async function checkSubmittedJudges() {
+        console.log("Refreshing submitted judge count by counting current_projects array lengths")
+        const justListRes = await getRequest<Judge[]>('/judge/list')
+        if (justListRes.status !== 200) {
+            errorAlert(justListRes);
+            return;
+        }
+        if (justListRes.data){
+            let numSubmitted = 0
+            justListRes.data.forEach(j => {
+                if (j.current_rankings.length == 0) numSubmitted++
+            })
+            setSubmittedJudges(numSubmitted)
+        }
     }
 
     if (loading) {
@@ -92,14 +110,16 @@ const Admin = () => {
                 className="absolute top-6 left-[16rem] w-40 md:w-52 text-lg py-2 px-1 hover:scale-100 focus:scale-100 rounded-md font-bold"
             >Settings</Button>
             <AdminStatsPanel />
-            <div className="w-full flex flex-row center items-center justify-center my-5">
+            <div className="w-full grid grid-cols-3 justify-center justify-items-center items-center my-5">
+                <div></div>
                 <Button
                     type="error"
                     onClick={endJudging}
                     disabled={judgingEnded}
                     bold
-                    className="w-1/3 md:w-1/4"
-                >{judgingEnded ? `Submitted judges: ${1}/${numJudges}` : "End Judging"}</Button>
+                    className="justify-self-stretch md:w-full w-full"
+                >{judgingEnded ? `Submitted judges: ${submittedJudges}/${numJudges}` : "End Judging"}</Button>
+                <div hidden={!judgingEnded} onClick={checkSubmittedJudges} className="justify-self-start cursor-pointer" title="Refresh submitted judges">🔁</div>
             </div>
             <AdminToggleSwitch state={showProjects} setState={setShowProjects} />
             <AdminToolbar showProjects={showProjects} />

--- a/client/src/pages/admin/index.tsx
+++ b/client/src/pages/admin/index.tsx
@@ -5,7 +5,7 @@ import AdminToggleSwitch from '../../components/admin/AdminToggleSwitch';
 import AdminToolbar from '../../components/admin/AdminToolbar';
 import JuryHeader from '../../components/JuryHeader';
 import Loading from '../../components/Loading';
-import { postRequest } from '../../api';
+import {getRequest, postRequest} from '../../api';
 import { errorAlert } from '../../util';
 import { useNavigate } from 'react-router-dom';
 import Button from '../../components/Button';
@@ -16,6 +16,8 @@ const Admin = () => {
     const navigate = useNavigate();
     const [showProjects, setShowProjects] = useState(true);
     const [loading, setLoading] = useState(true);
+    const [judgingEnded, setJudgingEnded] = useState(false);
+    const [numJudges, setNumJudges] = useState(0);
 
     useEffect(() => {
         // Check if user logged in
@@ -33,9 +35,48 @@ const Admin = () => {
 
             errorAlert(loggedInRes);
         }
-
         checkLoggedIn();
+
+        async function getNumJudges() {
+            const judgeListRes = await getRequest<Judge[]>('/judge/list')
+            if (judgeListRes.status !== 200) {
+                errorAlert(judgeListRes);
+                return;
+            }
+            setNumJudges(judgeListRes.data?.length as number);
+
+        }
+        getNumJudges();
+
+        async function checkJudgingEnded() {
+            // const judgingEndedRes = await getRequest<OkResponse>('/admin/end_judging')
+            setJudgingEnded(false)
+        }
+        checkJudgingEnded();
     }, []);
+
+    function endJudging() {
+        let confirmed = window.confirm("Are you sure you want to end judging? This cannot be undone.\n" +
+            "Judges will not be able to request new projects to rank and must submit rankings.")
+        if (confirmed) {
+            endJudgingReq().then(success => {
+                if (success) {
+                    alert("Judging has now been ended. Judges will be notified and made to submit their rankings. " +
+                        "Wait until all have submitted before recording final results.")
+                    setJudgingEnded(true)
+                } else {
+                    alert("Failed to end judging.")
+                }
+            })
+        }
+    }
+
+    async function endJudgingReq() {
+        console.log("Requesting server to end judging.")
+        // const endJudgingRes = await postRequest<OkResponse>('/admin/end_judging', null)
+        // lucatodo: pause and remove clock
+        return true
+    }
 
     if (loading) {
         return <Loading disabled={!loading} />;
@@ -51,6 +92,15 @@ const Admin = () => {
                 className="absolute top-6 left-[16rem] w-40 md:w-52 text-lg py-2 px-1 hover:scale-100 focus:scale-100 rounded-md font-bold"
             >Settings</Button>
             <AdminStatsPanel />
+            <div className="w-full flex flex-row center items-center justify-center my-5">
+                <Button
+                    type="error"
+                    onClick={endJudging}
+                    disabled={judgingEnded}
+                    bold
+                    className="w-1/3 md:w-1/4"
+                >{judgingEnded ? `Submitted judges: ${1}/${numJudges}` : "End Judging"}</Button>
+            </div>
             <AdminToggleSwitch state={showProjects} setState={setShowProjects} />
             <AdminToolbar showProjects={showProjects} />
             <AdminTable showProjects={showProjects} />

--- a/client/src/pages/admin/index.tsx
+++ b/client/src/pages/admin/index.tsx
@@ -23,7 +23,7 @@ const Admin = () => {
     useEffect(() => {
         // Check if user logged in
         async function checkLoggedIn() {
-            const loggedInRes = await postRequest<OkResponse>('/admin/auth', null);
+            const loggedInRes = await postRequest<YesNoResponse>('/admin/auth', null);
             if (loggedInRes.status === 401) {
                 console.error(`Admin is not logged in!`);
                 navigate('/');
@@ -81,7 +81,7 @@ const Admin = () => {
 
     async function endJudgingReq() {
         console.log("Requesting server to end judging.")
-        const endJudgingRes = await postRequest<OkResponse>('/admin/end-judging', null)
+        const endJudgingRes = await postRequest<YesNoResponse>('/admin/end-judging', null)
         return endJudgingRes.status === 200;
     }
 

--- a/client/src/pages/admin/index.tsx
+++ b/client/src/pages/admin/index.tsx
@@ -16,7 +16,7 @@ const Admin = () => {
     const navigate = useNavigate();
     const [showProjects, setShowProjects] = useState(true);
     const [loading, setLoading] = useState(true);
-    const [judgingEnded, setJudgingEnded] = useState(false);
+    const [judgingIsOver, setJudgingIsOver] = useState(false);
     const [numJudges, setNumJudges] = useState(0);
     const [submittedJudges, setSubmittedJudges] = useState(0);
 
@@ -56,7 +56,7 @@ const Admin = () => {
                 errorAlert(judgingEndedRes);
                 return;
             }
-            setJudgingEnded(Boolean(judgingEndedRes.data?.yes_no));
+            setJudgingIsOver(Boolean(judgingEndedRes.data?.yes_no));
         }
         checkJudgingEnded();
     }, []);
@@ -69,11 +69,11 @@ const Admin = () => {
                 if (success) {
                     alert("Judging has now been ended. Judges will be notified and made to submit their rankings. " +
                         "Wait until all have submitted before recording final results.");
-                    setJudgingEnded(true);
+                    setJudgingIsOver(true);
                     checkSubmittedJudges();
                 } else {
                     alert("Failed to end judging.");
-                    setJudgingEnded(false);
+                    setJudgingIsOver(false);
                 }
             })
         }
@@ -120,11 +120,11 @@ const Admin = () => {
                 <Button
                     type="error"
                     onClick={endJudging}
-                    disabled={judgingEnded}
+                    disabled={judgingIsOver}
                     bold
                     className="justify-self-stretch md:w-full w-full"
-                >{judgingEnded ? `Submitted judges: ${submittedJudges}/${numJudges}` : "End Judging"}</Button>
-                <div hidden={!judgingEnded} onClick={checkSubmittedJudges} className="justify-self-start cursor-pointer" title="Refresh submitted judges">🔁</div>
+                >{judgingIsOver ? `Submitted judges: ${submittedJudges}/${numJudges}` : "End Judging"}</Button>
+                <div hidden={!judgingIsOver} onClick={checkSubmittedJudges} className="justify-self-start cursor-pointer" title="Refresh submitted judges">🔁</div>
             </div>
             <AdminToggleSwitch state={showProjects} setState={setShowProjects} />
             <AdminToolbar showProjects={showProjects} />

--- a/client/src/pages/admin/settings.tsx
+++ b/client/src/pages/admin/settings.tsx
@@ -24,7 +24,7 @@ const AdminSettings = () => {
     const [judgingTimer, setJudgingTimer] = useState('');
     const [minViews, setMinViews] = useState('');
     const [categories, setCategories] = useState('');
-    const [rankingBatchSize, setRankingBatchSize] = useState('');
+    const [batchRankingSize, setBatchRankingSize] = useState('');
     const [loading, setLoading] = useState(true);
 
     async function getOptions() {
@@ -54,8 +54,8 @@ const AdminSettings = () => {
         // Set min views
         setMinViews(res.data.min_views.toString());
 
-        // Set ranking batch size
-        setRankingBatchSize(res.data.ranking_batch_size.toString())
+        // Set batch ranking size
+        setBatchRankingSize(res.data.batch_ranking_size.toString())
         setLoading(false);
     }
 
@@ -147,22 +147,22 @@ const AdminSettings = () => {
         getOptions();
     };
 
-    const updateRankingBatchSize = async () => {
-        // Convert rankingBatchSize to integer
-        const r = parseInt(rankingBatchSize);
+    const updateBatchRankingSize = async () => {
+        // Convert batchRankingSize to integer
+        const r = parseInt(batchRankingSize);
         if (isNaN(r) || r < 2) {
-            alert('Minimum views should be a positive integer >= 2!');
+            alert('Minimum batch ranking size should be a positive integer >= 2!');
             return;
         }
-        const res = await postRequest<YesNoResponse>('/admin/ranking-batch-size', {
-            ranking_batch_size: r,
+        const res = await postRequest<YesNoResponse>('/admin/batch-ranking-size', {
+            batch_ranking_size: r,
         });
         if (res.status !== 200 || res.data?.yes_no !== 1) {
             errorAlert(res);
             return;
         }
 
-        alert('Ranking Batch Size updated!');
+        alert('Batch Ranking Size updated!');
         getOptions();
     }
 
@@ -294,7 +294,7 @@ const AdminSettings = () => {
                     Update Categories
                 </Button>
 
-                <SubSection>Set Ranking Batch Size</SubSection>
+                <SubSection>Set Batch Ranking Size (BRS)</SubSection>
                 <Description>
                     Set how many projects judges rank at a time (must be at least 2 obviously).
                     Judges can rank and reorder projects freely before submitting a batch of the specified size.
@@ -305,17 +305,17 @@ const AdminSettings = () => {
                     type="number"
                     min="2"
                     placeholder="8"
-                    value={rankingBatchSize}
+                    value={batchRankingSize}
                     onChange={(e) => {
-                        setRankingBatchSize(e.target.value.toString());
+                        setBatchRankingSize(e.target.value.toString());
                     }}
                 />
                 <Button
                     type="primary"
-                    onClick={updateRankingBatchSize}
+                    onClick={updateBatchRankingSize}
                     className="mt-4 w-auto md:w-auto px-4 py-2"
                 >
-                    Update Ranking Batch Size
+                    Update Batch Ranking Size
                 </Button>
 
                 <Section>Judging Parameters</Section>

--- a/client/src/pages/admin/settings.tsx
+++ b/client/src/pages/admin/settings.tsx
@@ -65,8 +65,8 @@ const AdminSettings = () => {
     }, []);
 
     const reassignTables = async () => {
-        const res = await postRequest<OkResponse>('/project/reassign', null);
-        if (res.status !== 200 || res.data?.ok !== 1) {
+        const res = await postRequest<YesNoResponse>('/project/reassign', null);
+        if (res.status !== 200 || res.data?.yes_no !== 1) {
             errorAlert(res);
             return;
         }
@@ -90,10 +90,10 @@ const AdminSettings = () => {
         }
 
         // Update the timer
-        const res = await postRequest<OkResponse>('/admin/timer', {
+        const res = await postRequest<YesNoResponse>('/admin/timer', {
             judging_timer: timer,
         });
-        if (res.status !== 200 || res.data?.ok !== 1) {
+        if (res.status !== 200 || res.data?.yes_no !== 1) {
             errorAlert(res);
             return;
         }
@@ -111,10 +111,10 @@ const AdminSettings = () => {
         }
 
         // Update min views
-        const res = await postRequest<OkResponse>('/admin/min-views', {
+        const res = await postRequest<YesNoResponse>('/admin/min-views', {
             min_views: v,
         });
-        if (res.status !== 200 || res.data?.ok !== 1) {
+        if (res.status !== 200 || res.data?.yes_no !== 1) {
             errorAlert(res);
             return;
         }
@@ -135,10 +135,10 @@ const AdminSettings = () => {
             return
         }
         // Post the new categories
-        const res = await postRequest<OkResponse>('/admin/categories', {
+        const res = await postRequest<YesNoResponse>('/admin/categories', {
             categories: filteredCats,
         });
-        if (res.status !== 200 || res.data?.ok !== 1) {
+        if (res.status !== 200 || res.data?.yes_no !== 1) {
             errorAlert(res);
             return;
         }
@@ -154,10 +154,10 @@ const AdminSettings = () => {
             alert('Minimum views should be a positive integer >= 2!');
             return;
         }
-        const res = await postRequest<OkResponse>('/admin/ranking-batch-size', {
+        const res = await postRequest<YesNoResponse>('/admin/ranking-batch-size', {
             ranking_batch_size: r,
         });
-        if (res.status !== 200 || res.data?.ok !== 1) {
+        if (res.status !== 200 || res.data?.yes_no !== 1) {
             errorAlert(res);
             return;
         }
@@ -167,8 +167,8 @@ const AdminSettings = () => {
     }
 
     const resetClock = async () => {
-        const res = await postRequest<OkResponse>('/admin/clock/reset', null);
-        if (res.status !== 200 || res.data?.ok !== 1) {
+        const res = await postRequest<YesNoResponse>('/admin/clock/reset', null);
+        if (res.status !== 200 || res.data?.yes_no !== 1) {
             errorAlert(res);
             return;
         }
@@ -178,8 +178,8 @@ const AdminSettings = () => {
     };
 
     const dropDatabase = async () => {
-        const res = await postRequest<OkResponse>('/admin/reset', null);
-        if (res.status !== 200 || res.data?.ok !== 1) {
+        const res = await postRequest<YesNoResponse>('/admin/reset', null);
+        if (res.status !== 200 || res.data?.yes_no !== 1) {
             errorAlert(res);
             return;
         }

--- a/client/src/pages/judge/index.tsx
+++ b/client/src/pages/judge/index.tsx
@@ -52,7 +52,7 @@ const Judge = () => {
     useEffect(() => {
         async function fetchData() {
             // Check to see if the user is logged in
-            const loggedInRes = await postRequest<OkResponse>('/judge/auth', null);
+            const loggedInRes = await postRequest<YesNoResponse>('/judge/auth', null);
             if (loggedInRes.status === 401) {
                 console.error(`Judge is not logged in!`);
                 navigate('/');
@@ -62,19 +62,19 @@ const Judge = () => {
                 errorAlert(loggedInRes);
                 return;
             }
-            if (loggedInRes.data?.ok !== 1) {
+            if (loggedInRes.data?.yes_no !== 1) {
                 console.error(`Judge is not logged in!`);
                 navigate('/');
                 return;
             }
 
             // Check for read welcome
-            const readWelcomeRes = await getRequest<OkResponse>('/judge/welcome');
+            const readWelcomeRes = await getRequest<YesNoResponse>('/judge/welcome');
             if (readWelcomeRes.status !== 200) {
                 errorAlert(readWelcomeRes);
                 return;
             }
-            const readWelcome = readWelcomeRes.data?.ok === 1;
+            const readWelcome = readWelcomeRes.data?.yes_no === 1;
             if (!readWelcome) {
                 navigate('/judge/welcome');
             }
@@ -158,7 +158,7 @@ const Judge = () => {
             return;
         }
 
-        const res = await postRequest<OkResponse>('/judge/break', null);
+        const res = await postRequest<YesNoResponse>('/judge/break', null);
         if (res.status !== 200) {
             errorAlert(res);
             return;
@@ -257,7 +257,7 @@ const Judge = () => {
 
     const saveSort = async (projects: SortableJudgedProject[]) => {
         // Save the rankings
-        const saveRes = await postRequest<OkResponse>('/judge/rank', {
+        const saveRes = await postRequest<YesNoResponse>('/judge/rank', {
             ranking: projects.map((p) => p.project_id),
         });
         if (saveRes.status !== 200) {
@@ -271,7 +271,7 @@ const Judge = () => {
             alert(`You can only submit rankings in batches of ${rankingBatchSize} projects.`)
             return
         }
-        const submitRes = await postRequest<OkResponse>('/judge/submit-batch-ranking', {
+        const submitRes = await postRequest<YesNoResponse>('/judge/submit-batch-ranking', {
             batch_ranking: ranked.map((p) => p.project_id),
         });
         if (submitRes.status !== 200) {

--- a/client/src/pages/judge/index.tsx
+++ b/client/src/pages/judge/index.tsx
@@ -30,7 +30,7 @@ const Judge = () => {
     const [ranked, setRanked] = useState<SortableJudgedProject[]>([]);
     const [unranked, setUnranked] = useState<SortableJudgedProject[]>([]);
     const [allRanked, setAllRanked] = useState(false)
-    const [rankingBatchSize, setRankingBatchSize] = useState(0);
+    const [batchRankingSize, setBatchRankingSize] = useState(0);
     const [judgingIsOver, setJudgingIsOver] = useState(false);
     const [nextButtonDisabled, setNextButtonDisabled] = useState(false);
     const [nextButtonHelperText, setNextButtonHelperText] = useState('');
@@ -97,13 +97,13 @@ const Judge = () => {
             }
             setProjCount(projCountRes.data?.count as number);
 
-            // Get Ranking Batch Size
-            const rankingBatchSizeRes = await getRequest<RankingBatchSize>('/rbs');
-            if (rankingBatchSizeRes.status !== 200) {
-                errorAlert(rankingBatchSizeRes);
+            // Get Batch Ranking Size
+            const batchRankingSizeRes = await getRequest<BatchRankingSize>('/brs');
+            if (batchRankingSizeRes.status !== 200) {
+                errorAlert(batchRankingSizeRes);
                 return;
             }
-            setRankingBatchSize(rankingBatchSizeRes.data?.rbs as number);
+            setBatchRankingSize(batchRankingSizeRes.data?.brs as number);
 
             const judgingEndedRes = await getRequest<YesNoResponse>('/check-judging-over')
             if (judgingEndedRes.status !== 200) {
@@ -143,12 +143,12 @@ const Judge = () => {
         setLoaded(true);
     }, [judge]);
 
-    // Trigger button state ranking batch logic updates when `rankingBatchSize` is set (>0) and/or whenever `ranked` or `unranked` states chance
+    // Trigger button state ranking batch logic updates when `batchRankingSize` is set (>0) and/or whenever `ranked` or `unranked` states chance
     useEffect(() => {
-        if (rankingBatchSize > 0) {
-            setAllRanked((ranked.length === rankingBatchSize || judgingIsOver) && unranked.length === 0);
+        if (batchRankingSize > 0) {
+            setAllRanked((ranked.length === batchRankingSize || judgingIsOver) && unranked.length === 0);
 
-            if (ranked.length + unranked.length === rankingBatchSize) {
+            if (ranked.length + unranked.length === batchRankingSize) {
                 setNextButtonHelperText('Rank and submit your current batch to move on');
                 setNextButtonDisabled(true);
             } else {
@@ -156,7 +156,7 @@ const Judge = () => {
                 if (!judgingIsOver) setNextButtonDisabled(false);
             }
         }
-    }, [rankingBatchSize, judgingIsOver, ranked, unranked, loaded]);
+    }, [batchRankingSize, judgingIsOver, ranked, unranked, loaded]);
 
     if (!loaded) return <Loading disabled={!loaded} />;
 
@@ -277,8 +277,8 @@ const Judge = () => {
     };
 
     const submitBatch = async () => {
-        if (ranked.length !== rankingBatchSize && !judgingIsOver) {
-            alert(`You can only submit rankings in batches of ${rankingBatchSize} projects.`)
+        if (ranked.length !== batchRankingSize && !judgingIsOver) {
+            alert(`You can only submit rankings in batches of ${batchRankingSize} projects.`)
             return
         }
         if (ranked.length === 0) {
@@ -363,7 +363,7 @@ const Judge = () => {
                     <div className="flex justify-center text-light text-sm italic text-center">
                         {/* lucatodo: text updates if judging is ended manually to allow 'early' submission (see issue #4) */}
                         Please rank all your projects to submit.<br/>
-                        <p hidden={judgingIsOver}>You can only submit rankings in batches of {rankingBatchSize} projects.</p>
+                        <p hidden={judgingIsOver}>You can only submit rankings in batches of {batchRankingSize} projects.</p>
                     </div>
                     <Button type="primary" full square className="mt-1" disabled={!allRanked} onClick={submitBatch}>
                         Submit Rankings

--- a/client/src/pages/judge/index.tsx
+++ b/client/src/pages/judge/index.tsx
@@ -271,7 +271,7 @@ const Judge = () => {
             alert(`You can only submit rankings in batches of ${rankingBatchSize} projects.`)
             return
         }
-        const submitRes = await postRequest<OkResponse>('/judge/submit_batch_ranking', {
+        const submitRes = await postRequest<OkResponse>('/judge/submit-batch-ranking', {
             batch_ranking: ranked.map((p) => p.project_id),
         });
         if (submitRes.status !== 200) {

--- a/client/src/pages/judge/index.tsx
+++ b/client/src/pages/judge/index.tsx
@@ -105,12 +105,12 @@ const Judge = () => {
             }
             setBatchRankingSize(batchRankingSizeRes.data?.brs as number);
 
-            const judgingEndedRes = await getRequest<YesNoResponse>('/check-judging-over')
-            if (judgingEndedRes.status !== 200) {
-                errorAlert(judgingEndedRes);
+            const judgingOverRes = await getRequest<YesNoResponse>('/check-judging-over')
+            if (judgingOverRes.status !== 200) {
+                errorAlert(judgingOverRes);
                 return;
             }
-            let judgingIsOver = Boolean(judgingEndedRes.data?.yes_no)
+            let judgingIsOver = Boolean(judgingOverRes.data?.yes_no)
             setJudgingIsOver(judgingIsOver);
             setNextButtonDisabled(judgingIsOver);
         }

--- a/client/src/pages/judge/index.tsx
+++ b/client/src/pages/judge/index.tsx
@@ -31,6 +31,7 @@ const Judge = () => {
     const [unranked, setUnranked] = useState<SortableJudgedProject[]>([]);
     const [allRanked, setAllRanked] = useState(false)
     const [rankingBatchSize, setRankingBatchSize] = useState(0);
+    const [judgingIsOver, setJudgingIsOver] = useState(false);
     const [nextButtonDisabled, setNextButtonDisabled] = useState(false);
     const [nextButtonHelperText, setNextButtonHelperText] = useState('');
     const [loaded, setLoaded] = useState(false);
@@ -103,6 +104,15 @@ const Judge = () => {
                 return;
             }
             setRankingBatchSize(rankingBatchSizeRes.data?.rbs as number);
+
+            const judgingEndedRes = await getRequest<YesNoResponse>('/check-judging-over')
+            if (judgingEndedRes.status !== 200) {
+                errorAlert(judgingEndedRes);
+                return;
+            }
+            let judgingIsOver = Boolean(judgingEndedRes.data?.yes_no)
+            setJudgingIsOver(judgingIsOver);
+            setNextButtonDisabled(judgingIsOver);
         }
 
         fetchData();
@@ -136,17 +146,17 @@ const Judge = () => {
     // Trigger button state ranking batch logic updates when `rankingBatchSize` is set (>0) and/or whenever `ranked` or `unranked` states chance
     useEffect(() => {
         if (rankingBatchSize > 0) {
-            setAllRanked(ranked.length === rankingBatchSize && unranked.length === 0);
+            setAllRanked((ranked.length === rankingBatchSize || judgingIsOver) && unranked.length === 0);
 
             if (ranked.length + unranked.length === rankingBatchSize) {
                 setNextButtonHelperText('Rank and submit your current batch to move on');
                 setNextButtonDisabled(true);
             } else {
                 setNextButtonHelperText('');
-                setNextButtonDisabled(false);
+                if (!judgingIsOver) setNextButtonDisabled(false);
             }
         }
-    }, [rankingBatchSize, ranked, unranked, loaded]);
+    }, [rankingBatchSize, judgingIsOver, ranked, unranked, loaded]);
 
     if (!loaded) return <Loading disabled={!loaded} />;
 
@@ -267,10 +277,15 @@ const Judge = () => {
     };
 
     const submitBatch = async () => {
-        if (ranked.length !== rankingBatchSize) {  // lucatodo: handle end of event
+        if (ranked.length !== rankingBatchSize && !judgingIsOver) {
             alert(`You can only submit rankings in batches of ${rankingBatchSize} projects.`)
             return
         }
+        if (ranked.length === 0) {
+            alert('You cannot submit an empty batch.')
+            return
+        }
+
         const submitRes = await postRequest<YesNoResponse>('/judge/submit-batch-ranking', {
             batch_ranking: ranked.map((p) => p.project_id),
         });
@@ -287,6 +302,10 @@ const Judge = () => {
         <>
             <JuryHeader withLogout />
             <Container noCenter className="px-2 pb-4">
+                <div className="w-full text-lg text-center italic bg-error" hidden={!judgingIsOver}>
+                    <p>Judging has been ended. You can no longer view new projects.</p>
+                    <p>Please rank your previously seen projects and submit.</p>
+                </div>
                 <h1 className="text-2xl my-2">Welcome, {judge?.name}!</h1>
                 <div className="w-full mb-6">
                     <Button type="primary" full square href="/judge/live" disabled={nextButtonDisabled}>
@@ -294,14 +313,15 @@ const Judge = () => {
                         <p className="text-sm italic">{nextButtonHelperText}</p>
                     </Button>
                     <div className="flex align-center justify-center mt-4">
-                        <Button type="outline" square onClick={takeBreak} className="text-lg p-2">
+                        <Button type="outline" square onClick={takeBreak} disabled={judgingIsOver} className="text-lg p-2">
                             I want to take a break!
                         </Button>
                     </div>
                 </div>
                 <div className="flex justify-evenly">
-                    <StatBlock name="Seen" value={judge?.seen_projects.length as number} />
-                    <StatBlock name="Total Projects" value={projCount} />
+                    <StatBlock name="Seen" value={judge?.seen_projects.length as number}/>
+                    <StatBlock name="Submitted Batches" value={judge?.past_rankings.length as number}/>
+                    <StatBlock name="Total Projects" value={projCount}/>
                 </div>
                 <DndContext
                     sensors={sensors}
@@ -343,11 +363,12 @@ const Judge = () => {
                     <div className="flex justify-center text-light text-sm italic text-center">
                         {/* lucatodo: text updates if judging is ended manually to allow 'early' submission (see issue #4) */}
                         Please rank all your projects to submit.<br/>
-                        You can only submit rankings in batches of {rankingBatchSize} projects.
+                        <p hidden={judgingIsOver}>You can only submit rankings in batches of {rankingBatchSize} projects.</p>
                     </div>
                     <Button type="primary" full square className="mt-1" disabled={!allRanked} onClick={submitBatch}>
                         Submit Rankings
-                        <p className="text-sm italic">And move onto next batch</p>
+                        <p className="text-sm italic" hidden={judgingIsOver}>and move onto next batch</p>
+                        <p className="text-sm italic" hidden={!judgingIsOver}>and finish judging. Thank you for your hard work!</p>
                     </Button>
                 </div>
             </Container>

--- a/client/src/pages/judge/live.tsx
+++ b/client/src/pages/judge/live.tsx
@@ -18,12 +18,13 @@ import alarm from '../../assets/alarm.mp3';
 import data from '../../data.json';
 import RawTextInput from '../../components/RawTextInput';
 
-const infoPages = ['paused', 'hidden', 'no-projects', 'done'];
+const infoPages = ['paused', 'hidden', 'no-projects', 'done', 'judging-ended'];
 const infoData = [
     data.judgeInfo.paused,
     data.judgeInfo.hidden,
     data.judgeInfo.noProjects,
     data.judgeInfo.done,
+    data.judgeInfo.judgingEnded,
 ];
 
 const audio = new Audio(alarm);
@@ -71,6 +72,17 @@ const JudgeLive = () => {
             const readWelcome = readWelcomeRes.data?.yes_no === 1;
             if (!readWelcome) {
                 navigate('/judge/welcome');
+            }
+
+            const judgingEndedRes = await getRequest<YesNoResponse>('/check-judging-over')
+            if (judgingEndedRes.status !== 200) {
+                errorAlert(judgingEndedRes);
+                return;
+            }
+            if (judgingEndedRes.data?.yes_no === 1) {
+                setVerified(true)
+                setInfoPage('judging-ended');
+                return;
             }
 
             // Check to see if judging has started

--- a/client/src/pages/judge/live.tsx
+++ b/client/src/pages/judge/live.tsx
@@ -51,35 +51,35 @@ const JudgeLive = () => {
     useEffect(() => {
         async function fetchData() {
             // Check to see if the user is logged in
-            const loggedInRes = await postRequest<OkResponse>('/judge/auth', null);
+            const loggedInRes = await postRequest<YesNoResponse>('/judge/auth', null);
             if (loggedInRes.status !== 200) {
                 errorAlert(loggedInRes);
                 return;
             }
-            if (loggedInRes.data?.ok !== 1) {
+            if (loggedInRes.data?.yes_no !== 1) {
                 console.error(`Judge is not logged in!`);
                 navigate('/');
                 return;
             }
 
             // Check for read welcome
-            const readWelcomeRes = await getRequest<OkResponse>('/judge/welcome');
+            const readWelcomeRes = await getRequest<YesNoResponse>('/judge/welcome');
             if (readWelcomeRes.status !== 200) {
                 errorAlert(readWelcomeRes);
                 return;
             }
-            const readWelcome = readWelcomeRes.data?.ok === 1;
+            const readWelcome = readWelcomeRes.data?.yes_no === 1;
             if (!readWelcome) {
                 navigate('/judge/welcome');
             }
 
             // Check to see if judging has started
-            const startedRes = await getRequest<OkResponse>('/admin/started');
+            const startedRes = await getRequest<YesNoResponse>('/admin/started');
             if (startedRes.status !== 200) {
                 errorAlert(startedRes);
                 return;
             }
-            if (startedRes.data?.ok !== 1) {
+            if (startedRes.data?.yes_no !== 1) {
                 setVerified(true);
                 setInfoPage('paused');
                 return;
@@ -231,7 +231,7 @@ const JudgeLive = () => {
 
         // Update notes if voting
         if (isVote) {
-            const res = await postRequest<OkResponse>('/judge/notes', {
+            const res = await postRequest<YesNoResponse>('/judge/notes', {
                 notes,
                 project: judge?.current,
             });

--- a/client/src/pages/judge/project.tsx
+++ b/client/src/pages/judge/project.tsx
@@ -33,7 +33,7 @@ const Project = () => {
         if (!project) return;
 
         async function updateNotes() {
-            const res = await postRequest<OkResponse>('/judge/notes', {
+            const res = await postRequest<YesNoResponse>('/judge/notes', {
                 notes,
                 project: project?.project_id,
             });

--- a/client/src/pages/judge/welcome.tsx
+++ b/client/src/pages/judge/welcome.tsx
@@ -18,12 +18,12 @@ const JudgeWelcome = () => {
     useEffect(() => {
         async function fetchData() {
             // Check to see if the user is logged in
-            const loggedInRes = await postRequest<OkResponse>('/judge/auth', null);
+            const loggedInRes = await postRequest<YesNoResponse>('/judge/auth', null);
             if (loggedInRes.status !== 200) {
                 errorAlert(loggedInRes);
                 return;
             }
-            if (loggedInRes.data?.ok !== 1) {
+            if (loggedInRes.data?.yes_no !== 1) {
                 console.error(`Judge is not logged in!`);
                 navigate('/');
                 return;
@@ -51,7 +51,7 @@ const JudgeWelcome = () => {
         }
 
         // POST to server to mark that the user has read the welcome message
-        const readWelcomeRes = await postRequest<OkResponse>('/judge/welcome', null);
+        const readWelcomeRes = await postRequest<YesNoResponse>('/judge/welcome', null);
         if (readWelcomeRes.status !== 200) {
             errorAlert(readWelcomeRes);
             return;

--- a/client/src/types.d.ts
+++ b/client/src/types.d.ts
@@ -98,8 +98,8 @@ interface ProjectCount {
     count: number;
 }
 
-interface RankingBatchSize {
-    rbs: number;
+interface BatchRankingSize {
+    brs: number;
 }
 
 interface Flag {
@@ -118,7 +118,7 @@ interface Options {
     clock: ClockState;
     judging_timer: number;
     categories: string[];
-    ranking_batch_size: number;
+    batch_ranking_size: number;
     min_views: number;
 }
 

--- a/client/src/types.d.ts
+++ b/client/src/types.d.ts
@@ -102,10 +102,6 @@ interface RankingBatchSize {
     rbs: number;
 }
 
-interface JudgingEnded {
-    judging_ended: boolean;
-}
-
 interface Flag {
     id: string;
     judge_id: string;

--- a/client/src/types.d.ts
+++ b/client/src/types.d.ts
@@ -102,6 +102,10 @@ interface RankingBatchSize {
     rbs: number;
 }
 
+interface JudgingEnded {
+    judging_ended: boolean;
+}
+
 interface Flag {
     id: string;
     judge_id: string;

--- a/client/src/types.d.ts
+++ b/client/src/types.d.ts
@@ -64,8 +64,8 @@ interface VotingProjectInfo {
     prev_location: number;
 }
 
-interface OkResponse {
-    ok: number;
+interface YesNoResponse {
+    yes_no: number;
 }
 
 interface TokenResponse {

--- a/server/database/admin.go
+++ b/server/database/admin.go
@@ -124,10 +124,10 @@ func UpdateMinViews(db *mongo.Database, minViews int) error {
 	return err
 }
 
-// UpdateRankingBatchSize will update the min views setting
-func UpdateRankingBatchSize(db *mongo.Database, rankingBatchSize int) error {
+// UpdateBatchRankingSize will update the min views setting
+func UpdateBatchRankingSize(db *mongo.Database, batchRankingSize int) error {
 	// Update the min views
-	_, err := db.Collection("options").UpdateOne(context.Background(), gin.H{}, gin.H{"$set": gin.H{"ranking_batch_size": rankingBatchSize}})
+	_, err := db.Collection("options").UpdateOne(context.Background(), gin.H{}, gin.H{"$set": gin.H{"batch_ranking_size": batchRankingSize}})
 	return err
 }
 

--- a/server/database/admin.go
+++ b/server/database/admin.go
@@ -127,7 +127,13 @@ func UpdateMinViews(db *mongo.Database, minViews int) error {
 // UpdateRankingBatchSize will update the min views setting
 func UpdateRankingBatchSize(db *mongo.Database, rankingBatchSize int) error {
 	// Update the min views
-	println(rankingBatchSize)
 	_, err := db.Collection("options").UpdateOne(context.Background(), gin.H{}, gin.H{"$set": gin.H{"ranking_batch_size": rankingBatchSize}})
+	return err
+}
+
+// SetEndJudging will set the judging_ended flag to true
+func SetEndJudging(db *mongo.Database) error {
+	// Update the min views
+	_, err := db.Collection("options").UpdateOne(context.Background(), gin.H{}, gin.H{"$set": gin.H{"judging_ended": true}})
 	return err
 }

--- a/server/database/options.go
+++ b/server/database/options.go
@@ -49,11 +49,11 @@ func GetMinViews(db *mongo.Database) (int64, error) {
 	return options.MinViews, err
 }
 
-// GetRankingBatchSize gets the ranking batch size option from the database
-func GetRankingBatchSize(db *mongo.Database) (int64, error) {
+// GetBatchRankingSize gets the ranking batch size option from the database
+func GetBatchRankingSize(db *mongo.Database) (int64, error) {
 	var options models.Options
 	err := db.Collection("options").FindOne(context.Background(), gin.H{}).Decode(&options)
-	return options.RankingBatchSize, err
+	return options.BatchRankingSize, err
 }
 
 // GetJudgingEnded gets the judgingEnded flag from the database

--- a/server/database/options.go
+++ b/server/database/options.go
@@ -55,3 +55,10 @@ func GetRankingBatchSize(db *mongo.Database) (int64, error) {
 	err := db.Collection("options").FindOne(context.Background(), gin.H{}).Decode(&options)
 	return options.RankingBatchSize, err
 }
+
+// GetJudgingEnded gets the judgingEnded flag from the database
+func GetJudgingEnded(db *mongo.Database) (bool, error) {
+	var options models.Options
+	err := db.Collection("options").FindOne(context.Background(), gin.H{}).Decode(&options)
+	return options.JudgingEnded, err
+}

--- a/server/models/options.go
+++ b/server/models/options.go
@@ -10,7 +10,7 @@ type Options struct {
 	JudgingTimer     int64              `bson:"judging_timer" json:"judging_timer"`
 	MinViews         int64              `bson:"min_views" json:"min_views"`
 	Categories       []string           `bson:"categories" json:"categories"`
-	RankingBatchSize int64              `bson:"ranking_batch_size" json:"ranking_batch_size"`
+	BatchRankingSize int64              `bson:"batch_ranking_size" json:"batch_ranking_size"`
 	JudgingEnded     bool               `bson:"judging_ended" json:"judging_ended"`
 }
 
@@ -22,7 +22,7 @@ func NewOptions() *Options {
 		MinViews:         3,
 		Clock:            *NewClockState(),
 		Categories:       []string{"Creativity/Innovation", "Technical Competence/Execution", "Research/Design", "Presentation"},
-		RankingBatchSize: 8,
+		BatchRankingSize: 8,
 		JudgingEnded:     false,
 	}
 }

--- a/server/models/options.go
+++ b/server/models/options.go
@@ -11,6 +11,7 @@ type Options struct {
 	MinViews         int64              `bson:"min_views" json:"min_views"`
 	Categories       []string           `bson:"categories" json:"categories"`
 	RankingBatchSize int64              `bson:"ranking_batch_size" json:"ranking_batch_size"`
+	JudgingEnded     bool               `bson:"judging_ended" json:"judging_ended"`
 }
 
 func NewOptions() *Options {
@@ -22,5 +23,6 @@ func NewOptions() *Options {
 		Clock:            *NewClockState(),
 		Categories:       []string{"Creativity/Innovation", "Technical Competence/Execution", "Research/Design", "Presentation"},
 		RankingBatchSize: 8,
+		JudgingEnded:     false,
 	}
 }

--- a/server/router/admin.go
+++ b/server/router/admin.go
@@ -33,7 +33,7 @@ func LoginAdmin(ctx *gin.Context) {
 
 	// Return status OK if the password matches
 	if req.Password == password {
-		ctx.JSON(http.StatusOK, gin.H{"ok": 1})
+		ctx.JSON(http.StatusOK, gin.H{"yes_no": 1})
 		return
 	}
 
@@ -46,7 +46,7 @@ func AdminAuthenticated(ctx *gin.Context) {
 	// This route will run the middleware first, and if the middleware
 	// passes, then that means the admin is authenticated
 
-	ctx.JSON(http.StatusOK, gin.H{"ok": 1})
+	ctx.JSON(http.StatusOK, gin.H{"yes_no": 1})
 }
 
 // GET /admin/stats - GetAdminStats returns stats about the system
@@ -163,9 +163,9 @@ func IsClockPaused(ctx *gin.Context) {
 
 	// Send OK
 	if clock.Running {
-		ctx.JSON(http.StatusOK, gin.H{"ok": 1})
+		ctx.JSON(http.StatusOK, gin.H{"yes_no": 1})
 	} else {
-		ctx.JSON(http.StatusOK, gin.H{"ok": 0})
+		ctx.JSON(http.StatusOK, gin.H{"yes_no": 0})
 	}
 }
 
@@ -182,7 +182,7 @@ func ResetDatabase(ctx *gin.Context) {
 	}
 
 	// Send OK
-	ctx.JSON(http.StatusOK, gin.H{"ok": 1})
+	ctx.JSON(http.StatusOK, gin.H{"yes_no": 1})
 }
 
 // POST /admin/flags - GetFlags returns all flags
@@ -328,7 +328,7 @@ func SetJudgingTimer(ctx *gin.Context) {
 	}
 
 	// Send OK
-	ctx.JSON(http.StatusOK, gin.H{"ok": 1})
+	ctx.JSON(http.StatusOK, gin.H{"yes_no": 1})
 }
 
 type SetCategoriesRequest struct {
@@ -356,7 +356,7 @@ func SetCategories(ctx *gin.Context) {
 	}
 
 	// Send OK
-	ctx.JSON(http.StatusOK, gin.H{"ok": 1})
+	ctx.JSON(http.StatusOK, gin.H{"yes_no": 1})
 }
 
 type MinViewsRequest struct {
@@ -387,7 +387,7 @@ func SetMinViews(ctx *gin.Context) {
 	}
 
 	// Send OK
-	ctx.JSON(http.StatusOK, gin.H{"ok": 1})
+	ctx.JSON(http.StatusOK, gin.H{"yes_no": 1})
 }
 
 // POST /admin/ranking-batch-size - sets the ranking batch size
@@ -410,7 +410,7 @@ func SetRankingBatchSize(ctx *gin.Context) {
 	}
 
 	// Send OK
-	ctx.JSON(http.StatusOK, gin.H{"ok": 1})
+	ctx.JSON(http.StatusOK, gin.H{"yes_no": 1})
 }
 
 // GET /admin/score - GetScores returns the calculated scores of all projects
@@ -490,7 +490,7 @@ func endJudging(ctx *gin.Context) {
 	PauseClock(ctx)
 
 	// Send OK
-	ctx.JSON(http.StatusOK, gin.H{"ok": 1})
+	ctx.JSON(http.StatusOK, gin.H{"yes_no": 1})
 }
 
 // contains checks if a string is in a list of strings

--- a/server/router/admin.go
+++ b/server/router/admin.go
@@ -370,8 +370,8 @@ type MinViewsRequest struct {
 	MinViews int `json:"min_views"`
 }
 
-type RankingBatchSizeRequest struct {
-	RBS int `json:"ranking_batch_size"`
+type BatchRankingSizeRequest struct {
+	BRS int `json:"batch_ranking_size"`
 }
 
 // POST /admin/min-views - sets the min views
@@ -397,22 +397,22 @@ func SetMinViews(ctx *gin.Context) {
 	ctx.JSON(http.StatusOK, gin.H{"yes_no": 1})
 }
 
-// POST /admin/ranking-batch-size - sets the ranking batch size
+// POST /admin/batch-ranking-size - sets the ranking batch size
 func SetRankingBatchSize(ctx *gin.Context) {
 	// Get the database from the context
 	db := ctx.MustGet("db").(*mongo.Database)
 
 	// Get the views
-	var rbsReq RankingBatchSizeRequest
-	err := ctx.BindJSON(&rbsReq)
+	var brsReq BatchRankingSizeRequest
+	err := ctx.BindJSON(&brsReq)
 	if err != nil {
 		ctx.JSON(http.StatusBadRequest, gin.H{"error": "error parsing request: " + err.Error()})
 	}
 
 	// Save the ranking batch size in the db
-	err = database.UpdateRankingBatchSize(db, rbsReq.RBS)
+	err = database.UpdateBatchRankingSize(db, brsReq.BRS)
 	if err != nil {
-		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "error saving ranking batch size: " + err.Error()})
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "error saving batch ranking size: " + err.Error()})
 		return
 	}
 

--- a/server/router/admin.go
+++ b/server/router/admin.go
@@ -468,7 +468,7 @@ func GetScores(ctx *gin.Context) {
 	ctx.JSON(http.StatusOK, scores)
 }
 
-// GET /check-judging-over - isJudgingEnded returns the value of the judging_ended flag
+// GET /check-judging-over - isJudgingEnded returns a yes_no indicating the value of the judging_ended boolean flag
 func isJudgingEnded(ctx *gin.Context) {
 	db := ctx.MustGet("db").(*mongo.Database)
 

--- a/server/router/admin.go
+++ b/server/router/admin.go
@@ -461,7 +461,7 @@ func GetScores(ctx *gin.Context) {
 	ctx.JSON(http.StatusOK, scores)
 }
 
-// GET /admin/end-judging - isJudgingEnded returns the value of the judging_ended flag
+// GET /check-judging-over - isJudgingEnded returns the value of the judging_ended flag
 func isJudgingEnded(ctx *gin.Context) {
 	db := ctx.MustGet("db").(*mongo.Database)
 
@@ -472,7 +472,13 @@ func isJudgingEnded(ctx *gin.Context) {
 		return
 	}
 
-	ctx.JSON(http.StatusOK, gin.H{"judging_ended": judgingEnded})
+	// no type conversion from bool to int directly :'( : https://stackoverflow.com/a/38627381/7253717
+	var judgingEndedVar int8
+	if judgingEnded {
+		judgingEndedVar = 1
+	}
+
+	ctx.JSON(http.StatusOK, gin.H{"yes_no": judgingEndedVar})
 }
 
 // POST /admin/end-judging - endJudging ends the judging process by setting the judging_ended flag to true

--- a/server/router/admin.go
+++ b/server/router/admin.go
@@ -413,7 +413,7 @@ func SetRankingBatchSize(ctx *gin.Context) {
 	ctx.JSON(http.StatusOK, gin.H{"ok": 1})
 }
 
-// /GET /admin/score - GetScores returns the calculated scores of all projects
+// GET /admin/score - GetScores returns the calculated scores of all projects
 func GetScores(ctx *gin.Context) {
 	// Get the database from the context
 	db := ctx.MustGet("db").(*mongo.Database)

--- a/server/router/init.go
+++ b/server/router/init.go
@@ -87,7 +87,7 @@ func NewRouter(db *mongo.Database) *gin.Engine {
 	judgeRouter.POST("/judge/skip", JudgeSkip)
 	judgeRouter.POST("/judge/score", JudgeScore)
 	judgeRouter.POST("/judge/rank", JudgeRank)
-	judgeRouter.POST("/judge/submit_batch_ranking", JudgeSubmitBatchRanking)
+	judgeRouter.POST("/judge/submit-batch-ranking", JudgeSubmitBatchRanking)
 	judgeRouter.PUT("/judge/score", JudgeUpdateScore)
 	judgeRouter.POST("/judge/break", JudgeBreak)
 

--- a/server/router/init.go
+++ b/server/router/init.go
@@ -133,7 +133,7 @@ func NewRouter(db *mongo.Database) *gin.Engine {
 	judgeRouter.POST("/judge/notes", JudgeUpdateNotes)
 	judgeRouter.GET("/rbs", GetRankingBatchSize)
 
-	adminRouter.GET("/admin/end-judging", isJudgingEnded)
+	defaultRouter.GET("/check-judging-over", isJudgingEnded)
 	adminRouter.POST("/admin/end-judging", endJudging)
 
 	// Serve frontend static files

--- a/server/router/init.go
+++ b/server/router/init.go
@@ -127,11 +127,13 @@ func NewRouter(db *mongo.Database) *gin.Engine {
 	judgeRouter.GET("/admin/timer", GetJudgingTimer)
 	adminRouter.POST("/admin/timer", SetJudgingTimer)
 	adminRouter.POST("/admin/min-views", SetMinViews)
-	adminRouter.POST("/admin/ranking-batch-size", SetRankingBatchSize)
+
+	judgeRouter.GET("/brs", GetRankingBatchSize)
+	adminRouter.POST("/admin/batch-ranking-size", SetRankingBatchSize)
+
 	adminRouter.POST("/admin/categories", SetCategories)
 	judgeRouter.GET("/categories", GetCategories)
 	judgeRouter.POST("/judge/notes", JudgeUpdateNotes)
-	judgeRouter.GET("/rbs", GetRankingBatchSize)
 
 	defaultRouter.GET("/check-judging-over", isJudgingEnded)
 	adminRouter.POST("/admin/end-judging", endJudging)

--- a/server/router/init.go
+++ b/server/router/init.go
@@ -105,7 +105,7 @@ func NewRouter(db *mongo.Database) *gin.Engine {
 	adminRouter.GET("/admin/stats", GetAdminStats)
 	adminRouter.GET("/admin/score", GetScores)
 	adminRouter.GET("/admin/clock", GetClock)
-	adminRouter.POST("/admin/clock/pause", PauseClock)
+	adminRouter.POST("/admin/clock/pause", PauseClockHandler)
 	adminRouter.POST("/admin/clock/unpause", UnpauseClock)
 	adminRouter.POST("/admin/clock/reset", ResetClock)
 	adminRouter.POST("/admin/auth", AdminAuthenticated)

--- a/server/router/init.go
+++ b/server/router/init.go
@@ -133,6 +133,9 @@ func NewRouter(db *mongo.Database) *gin.Engine {
 	judgeRouter.POST("/judge/notes", JudgeUpdateNotes)
 	judgeRouter.GET("/rbs", GetRankingBatchSize)
 
+	adminRouter.GET("/admin/end-judging", isJudgingEnded)
+	adminRouter.POST("/admin/end-judging", endJudging)
+
 	// Serve frontend static files
 	router.Use(static.Serve("/assets", static.LocalFile("./public/assets", true)))
 	router.StaticFile("/favicon.ico", "./public/favicon.ico")

--- a/server/router/judge.go
+++ b/server/router/judge.go
@@ -516,20 +516,20 @@ func GetCategories(ctx *gin.Context) {
 	ctx.JSON(http.StatusOK, categories)
 }
 
-// GET /rbs - Endpoint to return ranking batch size
+// GET /brs - Endpoint to return ranking batch size
 func GetRankingBatchSize(ctx *gin.Context) {
 	// Get the database from the context
 	db := ctx.MustGet("db").(*mongo.Database)
 
 	// Get ranking batch size from database
-	rbs, err := database.GetRankingBatchSize(db)
+	brs, err := database.GetBatchRankingSize(db)
 	if err != nil {
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "error getting ranking batch size: " + err.Error()})
 		return
 	}
 
 	// Send OK
-	ctx.JSON(http.StatusOK, gin.H{"rbs": rbs})
+	ctx.JSON(http.StatusOK, gin.H{"brs": brs})
 }
 
 type UpdateScoreRequest struct {

--- a/server/router/judge.go
+++ b/server/router/judge.go
@@ -32,7 +32,7 @@ func GetJudge(ctx *gin.Context) {
 func JudgeAuthenticated(ctx *gin.Context) {
 	// This route will run the middleware first, and if the middleware
 	// passes, then that means the judge is authenticated
-	ctx.JSON(http.StatusOK, gin.H{"ok": 1})
+	ctx.JSON(http.StatusOK, gin.H{"yes_no": 1})
 }
 
 // GET /judge/welcome - Endpoint to check if a judge has read the welcome message
@@ -42,9 +42,9 @@ func CheckJudgeReadWelcome(ctx *gin.Context) {
 
 	// Send OK
 	if judge.ReadWelcome {
-		ctx.JSON(http.StatusOK, gin.H{"ok": 1})
+		ctx.JSON(http.StatusOK, gin.H{"yes_no": 1})
 	} else {
-		ctx.JSON(http.StatusOK, gin.H{"ok": 0})
+		ctx.JSON(http.StatusOK, gin.H{"yes_no": 0})
 	}
 }
 
@@ -67,7 +67,7 @@ func SetJudgeReadWelcome(ctx *gin.Context) {
 	}
 
 	// Send OK
-	ctx.JSON(http.StatusOK, gin.H{"ok": 1})
+	ctx.JSON(http.StatusOK, gin.H{"yes_no": 1})
 }
 
 // GET /judge/list - Endpoint to get a list of all judges
@@ -125,7 +125,7 @@ func DeleteJudge(ctx *gin.Context) {
 	}
 
 	// Send OK
-	ctx.JSON(http.StatusOK, gin.H{"ok": 1})
+	ctx.JSON(http.StatusOK, gin.H{"yes_no": 1})
 }
 
 // POST /judge/next - Endpoint to get the next project for a judge
@@ -266,7 +266,7 @@ func JudgeSkip(ctx *gin.Context) {
 	}
 
 	// Send OK
-	ctx.JSON(http.StatusOK, gin.H{"ok": 1})
+	ctx.JSON(http.StatusOK, gin.H{"yes_no": 1})
 }
 
 // POST /judge/hide - Endpoint to hide a judge
@@ -297,7 +297,7 @@ func HideJudge(ctx *gin.Context) {
 	}
 
 	// Send OK
-	ctx.JSON(http.StatusOK, gin.H{"ok": 1})
+	ctx.JSON(http.StatusOK, gin.H{"yes_no": 1})
 }
 
 // POST /judge/unhide - Endpoint to unhide a judge
@@ -329,7 +329,7 @@ func UnhideJudge(ctx *gin.Context) {
 	}
 
 	// Send OK
-	ctx.JSON(http.StatusOK, gin.H{"ok": 1})
+	ctx.JSON(http.StatusOK, gin.H{"yes_no": 1})
 }
 
 // PUT /judge/:id - Endpoint to edit a judge
@@ -363,7 +363,7 @@ func EditJudge(ctx *gin.Context) {
 	}
 
 	// Send OK
-	ctx.JSON(http.StatusOK, gin.H{"ok": 1})
+	ctx.JSON(http.StatusOK, gin.H{"yes_no": 1})
 }
 
 type JudgeScoreRequest struct {
@@ -404,7 +404,7 @@ func JudgeScore(ctx *gin.Context) {
 	}
 
 	// Send OK
-	ctx.JSON(http.StatusOK, gin.H{"ok": 1})
+	ctx.JSON(http.StatusOK, gin.H{"yes_no": 1})
 }
 
 type RankRequest struct {
@@ -435,7 +435,7 @@ func JudgeRank(ctx *gin.Context) {
 	}
 
 	// Send OK
-	ctx.JSON(http.StatusOK, gin.H{"ok": 1})
+	ctx.JSON(http.StatusOK, gin.H{"yes_no": 1})
 }
 
 type BatchRankingRequest struct {
@@ -469,7 +469,7 @@ func JudgeSubmitBatchRanking(ctx *gin.Context) {
 	}
 
 	// Send OK
-	ctx.JSON(http.StatusOK, gin.H{"ok": 1})
+	ctx.JSON(http.StatusOK, gin.H{"yes_no": 1})
 }
 
 // POST /judge/break - Allows a judge to take a break and free up their current project
@@ -497,7 +497,7 @@ func JudgeBreak(ctx *gin.Context) {
 	}
 
 	// Send OK
-	ctx.JSON(http.StatusOK, gin.H{"ok": 1})
+	ctx.JSON(http.StatusOK, gin.H{"yes_no": 1})
 }
 
 // GET /categories - Endpoint to get the categories
@@ -586,7 +586,7 @@ func JudgeUpdateScore(ctx *gin.Context) {
 	comps.UpdateProjectComparisonCount(judge.SeenProjects, scoreReq.Project)
 
 	// Send OK
-	ctx.JSON(http.StatusOK, gin.H{"ok": 1})
+	ctx.JSON(http.StatusOK, gin.H{"yes_no": 1})
 }
 
 type UpdateNotesRequest struct {
@@ -637,5 +637,5 @@ func JudgeUpdateNotes(ctx *gin.Context) {
 	}
 
 	// Send OK
-	ctx.JSON(http.StatusOK, gin.H{"ok": 1})
+	ctx.JSON(http.StatusOK, gin.H{"yes_no": 1})
 }

--- a/server/router/judge.go
+++ b/server/router/judge.go
@@ -442,7 +442,7 @@ type BatchRankingRequest struct {
 	BatchRanking []primitive.ObjectID `json:"batch_ranking"`
 }
 
-// POST /judge/submit_batch_ranking -
+// POST /judge/submit-batch-ranking -
 func JudgeSubmitBatchRanking(ctx *gin.Context) {
 	// Get the database from the context
 	db := ctx.MustGet("db").(*mongo.Database)

--- a/server/router/judge.go
+++ b/server/router/judge.go
@@ -521,7 +521,7 @@ func GetRankingBatchSize(ctx *gin.Context) {
 	// Get the database from the context
 	db := ctx.MustGet("db").(*mongo.Database)
 
-	// Get categories from database
+	// Get ranking batch size from database
 	rbs, err := database.GetRankingBatchSize(db)
 	if err != nil {
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "error getting ranking batch size: " + err.Error()})

--- a/server/router/project.go
+++ b/server/router/project.go
@@ -56,7 +56,7 @@ func AddDevpostCsv(ctx *gin.Context) {
 	}
 
 	// Send OK
-	ctx.JSON(http.StatusOK, gin.H{"ok": 1})
+	ctx.JSON(http.StatusOK, gin.H{"yes_no": 1})
 }
 
 type AddProjectRequest struct {
@@ -127,7 +127,7 @@ func AddProject(ctx *gin.Context) {
 	}
 
 	// Send OK
-	ctx.JSON(http.StatusOK, gin.H{"ok": 1})
+	ctx.JSON(http.StatusOK, gin.H{"yes_no": 1})
 }
 
 // GET /project/list - ListProjects lists all projects in the database
@@ -230,7 +230,7 @@ func AddProjectsCsv(ctx *gin.Context) {
 	}
 
 	// Send OK
-	ctx.JSON(http.StatusOK, gin.H{"ok": 1})
+	ctx.JSON(http.StatusOK, gin.H{"yes_no": 1})
 }
 
 // DELETE /project/:id - DeleteProject deletes a project from the database
@@ -256,7 +256,7 @@ func DeleteProject(ctx *gin.Context) {
 	}
 
 	// Send OK
-	ctx.JSON(http.StatusOK, gin.H{"ok": 1})
+	ctx.JSON(http.StatusOK, gin.H{"yes_no": 1})
 }
 
 // POST /project/stats - ProjectStats returns stats about projects
@@ -346,7 +346,7 @@ func HideProject(ctx *gin.Context) {
 	}
 
 	// Send OK
-	ctx.JSON(http.StatusOK, gin.H{"ok": 1})
+	ctx.JSON(http.StatusOK, gin.H{"yes_no": 1})
 }
 
 // POST /project/unhide - UnhideProject unhides a project
@@ -378,7 +378,7 @@ func UnhideProject(ctx *gin.Context) {
 	}
 
 	// Send OK
-	ctx.JSON(http.StatusOK, gin.H{"ok": 1})
+	ctx.JSON(http.StatusOK, gin.H{"yes_no": 1})
 }
 
 // POST /project/prioritize - PrioritizeProject prioritizes a project
@@ -410,7 +410,7 @@ func PrioritizeProject(ctx *gin.Context) {
 	}
 
 	// Send OK
-	ctx.JSON(http.StatusOK, gin.H{"ok": 1})
+	ctx.JSON(http.StatusOK, gin.H{"yes_no": 1})
 }
 
 // POST /project/unprioritize - UnprioritizeProject unprioritizes a project
@@ -442,7 +442,7 @@ func UnprioritizeProject(ctx *gin.Context) {
 	}
 
 	// Send OK
-	ctx.JSON(http.StatusOK, gin.H{"ok": 1})
+	ctx.JSON(http.StatusOK, gin.H{"yes_no": 1})
 }
 
 func ReassignProjectNums(ctx *gin.Context) {
@@ -458,7 +458,7 @@ func ReassignProjectNums(ctx *gin.Context) {
 
 	// If projects is empty, send OK
 	if len(projects) == 0 {
-		ctx.JSON(http.StatusOK, gin.H{"ok": 1})
+		ctx.JSON(http.StatusOK, gin.H{"yes_no": 1})
 		return
 	}
 
@@ -495,5 +495,5 @@ func ReassignProjectNums(ctx *gin.Context) {
 	}
 
 	// Send OK
-	ctx.JSON(http.StatusOK, gin.H{"ok": 1})
+	ctx.JSON(http.StatusOK, gin.H{"yes_no": 1})
 }


### PR DESCRIPTION
### Description

Allows admins to do the one time action of ending the judging. This sets a flag in the config database which ends judging and updates the frontend of judges (after a reload/navigation) to disable receiving further projects.

### Closes #4  

This addresses all the points raised in #4 namely:
- _"It allows judges to finish viewing their current project"_: this required no changes
- _"Stops giving judges new projects"_: the button and next project page are both disabled on the frontend and backend requests return an empty project once judging is ended.
- _"Forces submission of rankings, even when a ranking is incomplete (smaller than the ranking size)"_: the frontend allows submissions of batches which are smaller than the batch size and the backend validates this is the case. Note that judges must submit even batches of just one project to be noted as 'Submitted' on the admin dashboard. Batches of one do not affect overall project rankings.
