### PR TITLE
Implement bulk hiding projects (by guild or selection)

### DIFF
--- a/client/src/components/Button.tsx
+++ b/client/src/components/Button.tsx
@@ -51,6 +51,7 @@ const Button = (props: ButtonProps) => {
         : 'cursor-auto text-lighter bg-backgroundDark';
     const boldFormat = props.bold ? 'font-bold' : 'font-normal';
     const widthFormat = props.full ? 'w-full' : 'w-3/4 md:w-2/3';
+    const focusFormat = 'focus:outline-none focus:ring-inset focus:ring-4 focus:ring-backgroundDark focus:ring-opacity-100';
     const formatting = twMerge(
         defaultFormat,
         borderFormat,
@@ -58,6 +59,7 @@ const Button = (props: ButtonProps) => {
         squareFormat,
         boldFormat,
         widthFormat,
+        focusFormat,
         props.className
     );
 

--- a/client/src/components/admin/AdminStatsPanel.tsx
+++ b/client/src/components/admin/AdminStatsPanel.tsx
@@ -68,7 +68,7 @@ const AdminStatsPanel = () => {
     }, [paused, time]);
 
     return (
-        <div className="flex flex-row mt-8 w-full">
+        <div className="flex flex-row mt-8 w-full cursor-pointer" onClick={fetchStats} title="Click to refresh stats">
             <PauseButton paused={paused} setPaused={setPaused} clock={time} />
             <div className="flex justify-evenly basis-2/5">
                 <StatBlock name="Projects" value={stats.projects} />
@@ -81,8 +81,8 @@ const AdminStatsPanel = () => {
                 className={'basis-1/5' + (paused ? ' text-error' : '')}
             />
             <div className="flex justify-evenly basis-2/5">
-                <StatBlock name="Avg Projects Seen/Judge" value={stats.avg_judge_seen} />
-                <StatBlock name="Judges" value={stats.judges} />
+                <StatBlock name="Avg Projects Seen/Judge" value={stats.avg_judge_seen}/>
+                <StatBlock name="Judges" value={stats.judges}/>
             </div>
         </div>
     );

--- a/client/src/components/admin/AdminStatsPanel.tsx
+++ b/client/src/components/admin/AdminStatsPanel.tsx
@@ -72,7 +72,8 @@ const AdminStatsPanel = () => {
             <PauseButton paused={paused} setPaused={setPaused} clock={time} />
             <div className="flex justify-evenly basis-2/5">
                 <StatBlock name="Projects" value={stats.projects} />
-                <StatBlock name="Avg Times Seen/Project" value={stats.avg_project_seen} />
+                <StatBlock name="Hidden Projects" value={stats.hidden_projects} />
+                <StatBlock name="Avg Seen/Project" value={stats.avg_project_seen} />
             </div>
             <StatBlock
                 name="Judging Time"

--- a/client/src/components/admin/AdminToolbar.tsx
+++ b/client/src/components/admin/AdminToolbar.tsx
@@ -38,7 +38,7 @@ const AdminToolbar = (props: { showProjects: boolean }) => {
                 )}
             </div>
             <div className="ml-4 italic">
-                Click on headings to sort by that column.
+                Click on headings to sort by that column. This will clear your selections.
             </div>
             {showFlags && <FlagsPopup close={setShowFlags}/>}
         </div>

--- a/client/src/components/admin/AdminToolbar.tsx
+++ b/client/src/components/admin/AdminToolbar.tsx
@@ -14,7 +14,6 @@ const AdminToolbar = (props: { showProjects: boolean }) => {
                         bold
                         full
                         className="py-2 px-4 rounded-md"
-                        // lucatodo: remove ability to add judges from this admin portal
                         href='/admin/add-projects'
                     >
                         Add Projects

--- a/client/src/components/admin/FlagsPopup.tsx
+++ b/client/src/components/admin/FlagsPopup.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { getRequest } from '../../api';
-import { errorAlert, timeSince } from '../../util';
+import {errorAlert, timeSince, truncate} from '../../util';
 
 interface FlagsPopupProps {
     /* Function to modify the popup state variable */
@@ -98,7 +98,7 @@ const FlagsPopup = ({ close }: FlagsPopupProps) => {
                             className="flex flex-row items-center text-xl border-b-2 border-backgroundDark py-1"
                         >
                             <h2 className="basis-2/5 text-left text-lg text-black">
-                                {`[${flag.project_location}] ${flag.project_name.substring(0, 15)}`}
+                                {`[${flag.project_location}] ${truncate(flag.project_name, 20)}`}
                             </h2>
                             <h2 className="basis-1/5 text-left text-lg text-black">
                                 {flag.judge_name}

--- a/client/src/components/admin/add-projects/NewProjectForm.tsx
+++ b/client/src/components/admin/add-projects/NewProjectForm.tsx
@@ -46,7 +46,10 @@ const NewProjectForm = () => {
                 <h1 className="text-3xl mb-4">Add Project</h1>
                 <form className="flex flex-col w-full space-y-4" onSubmit={handleSubmit(onSubmit)}>
                     <TextInput name="name" placeholder="Name" register={register} />
-                    <TextInput name="location" placeholder="Team location" register={register} />
+                    <div className="flex flex-row w-full mt-4 space-x-6">
+                        <TextInput name="guild" placeholder="Guild" register={register}/>
+                        <TextInput name="location" placeholder="Team location" register={register}/>
+                    </div>
                     <TextArea
                         name="description"
                         placeholder="Description"

--- a/client/src/components/admin/tables/JudgeRow.tsx
+++ b/client/src/components/admin/tables/JudgeRow.tsx
@@ -72,7 +72,7 @@ const JudgeRow = ({ judge, idx, checked, handleCheckedChange }: JudgeRowProps) =
                     ></input>
                 </td>
                 <td>{judge.name}</td>
-                <td className="text-center">{judge.code}</td>
+                <td className="text-center">{judge.keycloak_user_id}</td>
                 <td className="text-center">{judge.seen}</td>
                 <td className="text-center">{judge.past_rankings ? judge.past_rankings.length : 0}</td>
                 <td className="text-center">{timeSince(judge.last_activity)}</td>

--- a/client/src/components/admin/tables/JudgesTable.tsx
+++ b/client/src/components/admin/tables/JudgesTable.tsx
@@ -92,13 +92,13 @@ const JudgesTable = () => {
                             align="left"
                         />
                         <HeaderEntry
-                            name="Email"
+                            name="Keycloak User ID"
                             updateSort={updateSort}
-                            sortField={JudgeSortField.Email}
+                            sortField={JudgeSortField.KeycloakUserId}
                             sortState={sortState}
                         />
                         <HeaderEntry
-                            name="Seen"
+                            name="Projects Seen"
                             updateSort={updateSort}
                             sortField={JudgeSortField.Seen}
                             sortState={sortState}

--- a/client/src/components/admin/tables/JudgesTable.tsx
+++ b/client/src/components/admin/tables/JudgesTable.tsx
@@ -92,13 +92,13 @@ const JudgesTable = () => {
                             align="left"
                         />
                         <HeaderEntry
-                            name="Keycloak User ID"
+                            name="Keycloak UserID"
                             updateSort={updateSort}
                             sortField={JudgeSortField.KeycloakUserId}
                             sortState={sortState}
                         />
                         <HeaderEntry
-                            name="Projects Seen"
+                            name="Projects fully seen (not skipped)"
                             updateSort={updateSort}
                             sortField={JudgeSortField.Seen}
                             sortState={sortState}

--- a/client/src/components/admin/tables/ProjectRow.tsx
+++ b/client/src/components/admin/tables/ProjectRow.tsx
@@ -98,7 +98,7 @@ const ProjectRow = ({project, idx, checked, handleCheckedChange}: ProjectRowProp
                 <td className="[&:not(:hover)]:truncate hover:break-words hover:text-wrap">{project.name}</td>
                 <td className="text-center py-1">
                     <input
-                        className="w-full md:w-2/3"
+                        className="w-full md:w-2/3 rounded-2xl"
                         name="location"
                         key={project.id}
                         defaultValue={project.location}

--- a/client/src/components/admin/tables/ProjectRow.tsx
+++ b/client/src/components/admin/tables/ProjectRow.tsx
@@ -96,6 +96,7 @@ const ProjectRow = ({project, idx, checked, handleCheckedChange}: ProjectRowProp
                     ></input>
                 </td>
                 <td className="[&:not(:hover)]:truncate hover:break-words hover:text-wrap">{project.name}</td>
+                <td className="text-center">{project.guild}</td>
                 <td className="text-center py-1">
                     <input
                         className="w-full md:w-2/3 rounded-2xl"

--- a/client/src/components/admin/tables/ProjectRow.tsx
+++ b/client/src/components/admin/tables/ProjectRow.tsx
@@ -88,7 +88,7 @@ const ProjectRow = ({project, idx, checked, handleCheckedChange}: ProjectRowProp
                 <td className="px-2">
                     <input
                         type="checkbox"
-                        checked={checked}
+                        checked={checked || false}
                         onChange={(e) => {
                             handleCheckedChange(e, idx);
                         }}

--- a/client/src/components/admin/tables/ProjectsTable.tsx
+++ b/client/src/components/admin/tables/ProjectsTable.tsx
@@ -74,8 +74,12 @@ const ProjectsTable = () => {
             case ProjectSortField.Name:
                 sortFunc = (a, b) => a.name.localeCompare(b.name) * asc;
                 break;
-            case ProjectSortField.Location:
-                sortFunc = (a, b) => a.location.localeCompare(b.location) * asc;
+            case ProjectSortField.GuildLocation:
+                sortFunc = (a, b) => {
+                    const guildComparison = a.guild.localeCompare(b.guild) * asc;
+                    if (guildComparison !== 0) return guildComparison;  // if guilds are different, just use those to sort
+                    return a.location.localeCompare(b.location) * asc;  // otherwise, secondary sort by location
+                };
                 break;
             case ProjectSortField.Score:
                 sortFunc = (a, b) => (a.score - b.score) * asc;
@@ -188,9 +192,15 @@ const ProjectsTable = () => {
                         align='left'
                     />
                     <HeaderEntry
+                        name="Guild"
+                        updateSort={updateSort}
+                        sortField={ProjectSortField.GuildLocation}
+                        sortState={sortState}
+                    />
+                    <HeaderEntry
                         name="Location"
                         updateSort={updateSort}
-                        sortField={ProjectSortField.Location}
+                        sortField={ProjectSortField.GuildLocation}
                         sortState={sortState}
                     />
                     <HeaderEntry

--- a/client/src/components/admin/tables/ProjectsTable.tsx
+++ b/client/src/components/admin/tables/ProjectsTable.tsx
@@ -124,11 +124,15 @@ const ProjectsTable = () => {
     const selectByGuild = () => {
         const selectedGuild = (document.getElementById('guild-select') as HTMLSelectElement).value;
         let toCheck: number[] = [];
-        projects.forEach((project, idx) => {
-            if (project.guild === selectedGuild) {
-                toCheck.push(idx);
-            }
-        });
+        if (selectedGuild === 'all') {
+            toCheck = projects.map((_, idx) => idx);
+        } else {
+            projects.forEach((project, idx) => {
+                if (project.guild === selectedGuild) {
+                    toCheck.push(idx);
+                }
+            });
+        }
 
         setChecked(() => {
             let newChecked: {[key: number]: boolean} = {};
@@ -175,6 +179,7 @@ const ProjectsTable = () => {
                         {guilds.sort().map((guild, idx) => (
                             <option key={idx} value={guild}>{guild}</option>
                         ))}
+                        <option key="all-guild" value="all" className="italic">*Select all*</option>
                         <option key="nil-guild" value="nil" className="italic">*Deselect all*</option>
                     </select>
                     <Button type="outline" square className="ml-2 py-2 px-4 rounded-md" onClick={selectByGuild}>

--- a/client/src/components/admin/tables/ProjectsTable.tsx
+++ b/client/src/components/admin/tables/ProjectsTable.tsx
@@ -9,14 +9,14 @@ const ProjectsTable = () => {
     const unsortedProjects = useAdminStore((state) => state.projects);
     const fetchProjects = useAdminStore((state) => state.fetchProjects);
     const [projects, setProjects] = useState<Project[]>([]);
-    const [checked, setChecked] = useState<{ [key: number]: boolean }>({});
+    const [checked, setChecked] = useState<boolean[]>([]);
     const [sortState, setSortState] = useState<SortState<ProjectSortField>>({
         field: ProjectSortField.None,
         ascending: true,
     });
 
     const handleCheckedChange = (e: React.ChangeEvent<HTMLInputElement>, i: number) => {
-        setChecked({
+        setChecked({  // this change of type is to stop React complaining about "a component is changing an uncontrolled input to be controlled"
             ...checked,
             [i]: e.target.checked,
         });
@@ -55,12 +55,7 @@ const ProjectsTable = () => {
 
     // When projects change, update projects and sort
     useEffect(() => {
-        // Reset checked state of all projects
-        const newCheckedState: { [key: number]: boolean } = {}
-        for (let i = 0; i < projects.length; i++) {
-            newCheckedState[i] = false;
-        }
-        setChecked(newCheckedState);
+        setChecked(Array(unsortedProjects.length).fill(false));
 
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         let sortFunc = (a: Project, b: Project) => 0;
@@ -87,11 +82,20 @@ const ProjectsTable = () => {
     }, [unsortedProjects, sortState]);
 
     const bulkHide = () => {
-        const toHide: string[] = [];
-        for (let i = 0; i < projects.length; i++) {
-            if (checked[i]) {
-                toHide.push(projects[i].id);
-            }
+        let toHide: string[] = [];
+        // I hate this btw. But react complains if it's just one consistent type...
+        if (Array.isArray(checked)) {  // checked is still an array from initialisation
+            // checked.forEach((value, index) => {
+            //     if (value) {
+            //         toHide.push(projects[index].id);
+            //     }
+            // });  // in this case we know that it's an array of all false
+        } else {  // checked has been made a dictionary
+            Object.entries(checked).forEach(([key, value]) => {
+                if (value) {
+                    toHide.push(projects[parseInt(key)].id);
+                }
+            });
         }
         console.log(toHide);
     }

--- a/client/src/components/admin/tables/ProjectsTable.tsx
+++ b/client/src/components/admin/tables/ProjectsTable.tsx
@@ -3,12 +3,13 @@ import ProjectRow from './ProjectRow';
 import useAdminStore from '../../../store';
 import HeaderEntry from './HeaderEntry';
 import { ProjectSortField } from '../../../enums';
+import Button from "../../Button";
 
 const ProjectsTable = () => {
     const unsortedProjects = useAdminStore((state) => state.projects);
     const fetchProjects = useAdminStore((state) => state.fetchProjects);
     const [projects, setProjects] = useState<Project[]>([]);
-    const [checked, setChecked] = useState<boolean[]>([]);
+    const [checked, setChecked] = useState<{ [key: number]: boolean }>({});
     const [sortState, setSortState] = useState<SortState<ProjectSortField>>({
         field: ProjectSortField.None,
         ascending: true,
@@ -54,7 +55,12 @@ const ProjectsTable = () => {
 
     // When projects change, update projects and sort
     useEffect(() => {
-        setChecked(Array(unsortedProjects.length).fill(false));
+        // Reset checked state of all projects
+        const newCheckedState: { [key: number]: boolean } = {}
+        for (let i = 0; i < projects.length; i++) {
+            newCheckedState[i] = false;
+        }
+        setChecked(newCheckedState);
 
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         let sortFunc = (a: Project, b: Project) => 0;
@@ -80,54 +86,78 @@ const ProjectsTable = () => {
         setProjects(unsortedProjects.sort(sortFunc));
     }, [unsortedProjects, sortState]);
 
+    const bulkHide = () => {
+        const toHide: string[] = [];
+        for (let i = 0; i < projects.length; i++) {
+            if (checked[i]) {
+                toHide.push(projects[i].id);
+            }
+        }
+        console.log(toHide);
+    }
+
     return (
         <div className="w-full px-8 pb-4">
+            <div className="ml-4">
+                <Button
+                    type="primary"
+                    square
+                    bold
+                    full
+                    className="py-2 px-4 rounded-md"
+                    onClick={() => {
+                        bulkHide();
+                    }}
+                >
+                    Hide Selected
+                </Button>
+            </div>
             <table className="table-fixed w-full text-lg">
                 <tbody>
-                    <tr>
-                        <th className="w-12"></th>
-                        <HeaderEntry
-                            name="Name"
-                            updateSort={updateSort}
-                            sortField={ProjectSortField.Name}
-                            sortState={sortState}
-                            align='left'
-                        />
-                        <HeaderEntry
-                            name="Location"
-                            updateSort={updateSort}
-                            sortField={ProjectSortField.Location}
-                            sortState={sortState}
-                        />
-                        <HeaderEntry
-                            name="Live Score"
-                            updateSort={updateSort}
-                            sortField={ProjectSortField.Score}
-                            sortState={sortState}
-                        />
-                        <HeaderEntry
-                            name="Seen"
-                            updateSort={updateSort}
-                            sortField={ProjectSortField.Seen}
-                            sortState={sortState}
-                        />
-                        <HeaderEntry
-                            name="Updated"
-                            updateSort={updateSort}
-                            sortField={ProjectSortField.Updated}
-                            sortState={sortState}
-                        />
-                        <th className="text-right w-24">Actions</th>
-                    </tr>
-                    {projects.map((project: Project, idx) => (
-                        <ProjectRow
-                            key={idx}
-                            idx={idx}
-                            project={project}
-                            checked={checked[idx]}
-                            handleCheckedChange={handleCheckedChange}
-                        />
-                    ))}
+                <tr>
+                    <th className="w-12"></th>
+                    <HeaderEntry
+                        name="Name"
+                        updateSort={updateSort}
+                        sortField={ProjectSortField.Name}
+                        sortState={sortState}
+                        align='left'
+                    />
+                    <HeaderEntry
+                        name="Location"
+                        updateSort={updateSort}
+                        sortField={ProjectSortField.Location}
+                        sortState={sortState}
+                    />
+                    <HeaderEntry
+                        name="Live Score"
+                        updateSort={updateSort}
+                        sortField={ProjectSortField.Score}
+                        sortState={sortState}
+                    />
+                    <HeaderEntry
+                        name="Seen"
+                        updateSort={updateSort}
+                        sortField={ProjectSortField.Seen}
+                        sortState={sortState}
+                    />
+                    <HeaderEntry
+                        name="Updated"
+                        updateSort={updateSort}
+                        sortField={ProjectSortField.Updated}
+                        sortState={sortState}
+                    />
+                    <th className="text-right w-24">Actions</th>
+                </tr>
+                {projects.map((project: Project, idx) => (
+                    <ProjectRow
+                        key={idx}
+                        idx={idx}
+                        project={project}
+                        checked={checked[idx]}
+                        handleCheckedChange={handleCheckedChange}
+                    />
+                ))}
                 </tbody>
             </table>
         </div>

--- a/client/src/components/admin/tables/ProjectsTable.tsx
+++ b/client/src/components/admin/tables/ProjectsTable.tsx
@@ -217,7 +217,7 @@ const ProjectsTable = () => {
                         sortState={sortState}
                     />
                     <HeaderEntry
-                        name="Seen"
+                        name="Seen (and not skipped)"
                         updateSort={updateSort}
                         sortField={ProjectSortField.Seen}
                         sortState={sortState}

--- a/client/src/components/admin/tables/ProjectsTable.tsx
+++ b/client/src/components/admin/tables/ProjectsTable.tsx
@@ -4,6 +4,8 @@ import useAdminStore from '../../../store';
 import HeaderEntry from './HeaderEntry';
 import { ProjectSortField } from '../../../enums';
 import Button from "../../Button";
+import {postRequest} from "../../../api";
+import {errorAlert} from "../../../util";
 
 const ProjectsTable = () => {
     const unsortedProjects = useAdminStore((state) => state.projects);
@@ -81,7 +83,7 @@ const ProjectsTable = () => {
         setProjects(unsortedProjects.sort(sortFunc));
     }, [unsortedProjects, sortState]);
 
-    const bulkHide = () => {
+    const bulkHide = async (hide: boolean) => {
         let toHide: string[] = [];
         // I hate this btw. But react complains if it's just one consistent type...
         if (Array.isArray(checked)) {  // checked is still an array from initialisation
@@ -97,24 +99,50 @@ const ProjectsTable = () => {
                 }
             });
         }
-        console.log(toHide);
+
+        if (toHide.length === 0) {
+            alert('No projects selected!');
+            return;
+        }
+
+        const res = await postRequest<YesNoResponse>('/project/hide-unhide-many', {ids: toHide, hide: hide});
+        if (res.status === 200) {
+            alert(`Projects ${hide ? 'hidden' : 'un-hidden'} successfully!`);
+            await fetchProjects();
+        } else {
+            errorAlert(res);
+        }
     }
 
     return (
         <div className="w-full px-8 pb-4">
-            <div className="ml-4">
-                <Button
-                    type="primary"
-                    square
-                    bold
-                    full
-                    className="py-2 px-4 rounded-md"
-                    onClick={() => {
-                        bulkHide();
-                    }}
-                >
-                    Hide Selected
-                </Button>
+            <div className="flex">
+                <div className="">
+                    <Button
+                        type="primary"
+                        square
+                        full
+                        className="py-2 px-4 rounded-md"
+                        onClick={() => {
+                            bulkHide(true);
+                        }}
+                    >
+                        Hide Selected
+                    </Button>
+                </div>
+                <div className="ml-4">
+                    <Button
+                        type="primary"
+                        square
+                        full
+                        className="py-2 px-4 rounded-md"
+                        onClick={() => {
+                            bulkHide(false);
+                        }}
+                    >
+                        Unhide Selected
+                    </Button>
+                </div>
             </div>
             <table className="table-fixed w-full text-lg">
                 <tbody>

--- a/client/src/components/admin/tables/ProjectsTable.tsx
+++ b/client/src/components/admin/tables/ProjectsTable.tsx
@@ -11,6 +11,7 @@ const ProjectsTable = () => {
     const unsortedProjects = useAdminStore((state) => state.projects);
     const fetchProjects = useAdminStore((state) => state.fetchProjects);
     const [projects, setProjects] = useState<Project[]>([]);
+    const [guilds, setGuilds] = useState<string[]>([]);
     const [checked, setChecked] = useState<boolean[]>([]);
     const [sortState, setSortState] = useState<SortState<ProjectSortField>>({
         field: ProjectSortField.None,
@@ -114,10 +115,14 @@ const ProjectsTable = () => {
         }
     }
 
+    useEffect(() => {
+        setGuilds(Array.from(new Set(projects.map(p => p.guild))));
+    }, [projects]);
+
     return (
         <div className="w-full px-8 pb-4">
-            <div className="flex">
-                <div className="">
+            <div className="flex flex-row w-full space-x-4 items-center text-center">
+                <div>
                     <Button
                         type="primary"
                         square
@@ -130,7 +135,7 @@ const ProjectsTable = () => {
                         Hide Selected
                     </Button>
                 </div>
-                <div className="ml-4">
+                <div>
                     <Button
                         type="primary"
                         square
@@ -142,6 +147,15 @@ const ProjectsTable = () => {
                     >
                         Unhide Selected
                     </Button>
+                </div>
+                <div className="flex flex-nowrap items-center pl-8">
+                    <label form="guild-select" className="text-2xl mr-2 align-middle">Guild:</label>
+                    <select name="guilds" id="guild-select" className="rounded-md align-middle">
+                        {guilds.map((guild, idx) => (
+                            <option key={idx} value={guild}>{guild}</option>
+                        ))}
+                    </select>
+                    <Button type="outline" square className="ml-2 py-2 px-4 rounded-md">Bulk select</Button>
                 </div>
             </div>
             <table className="table-fixed w-full text-lg">

--- a/client/src/components/admin/tables/ProjectsTable.tsx
+++ b/client/src/components/admin/tables/ProjectsTable.tsx
@@ -110,7 +110,7 @@ const ProjectsTable = () => {
 
         const res = await postRequest<YesNoResponse>('/project/hide-unhide-many', {ids: toHide, hide: hide});
         if (res.status === 200) {
-            alert(`Projects ${hide ? 'hidden' : 'un-hidden'} successfully!`);
+            alert(`${toHide.length} project(s) ${hide ? 'hidden' : 'unhidden'} successfully!`);
             await fetchProjects();
         } else {
             errorAlert(res);
@@ -168,16 +168,18 @@ const ProjectsTable = () => {
                         Unhide Selected
                     </Button>
                 </div>
+                <p className="text-2l text-nowrap">{Object.values(checked).filter(Boolean).length} project(s) currently selected</p>
                 <div className="flex flex-nowrap items-center pl-8">
                     <p className="text-2xl mr-2 align-middle">Guild:</p>
                     <select className="rounded-md align-middle" id="guild-select">
-                        {guilds.map((guild, idx) => (
+                        {guilds.sort().map((guild, idx) => (
                             <option key={idx} value={guild}>{guild}</option>
                         ))}
                         <option key="nil-guild" value="nil" className="italic">*Deselect all*</option>
                     </select>
                     <Button type="outline" square className="ml-2 py-2 px-4 rounded-md" onClick={selectByGuild}>
-                        Bulk select</Button>
+                        Bulk select
+                    </Button>
                 </div>
             </div>
             <table className="table-fixed w-full text-lg">

--- a/client/src/components/judge/ProjectDisplay.tsx
+++ b/client/src/components/judge/ProjectDisplay.tsx
@@ -46,7 +46,7 @@ const ProjectDisplay = (props: ProjectDisplayProps) => {
                     {project.name}
                 </a>
             </h1>
-            <h2 className="text-xl mb-1">Location (Guild|Table): {project.location}</h2>
+            <h2 className="text-xl mb-1">Location: {project.guild}|{project.location}</h2>
             <Paragraph className="text-light" text={project.description} />
         </div>
     );

--- a/client/src/components/judge/ProjectEntry.tsx
+++ b/client/src/components/judge/ProjectEntry.tsx
@@ -37,7 +37,7 @@ const ProjectEntry = ({ project, ranking }: ProjectEntryProps) => {
                     <div className="min-w-0">
                         <h3 className="text-xl grow">
                             <a href={`/judge/project/${project.project_id}`}>
-                                <b>{truncate(project.name, 10)}</b>&nbsp;({truncate(project.location, 20)})
+                                <b>{truncate(project.name, 15)}</b>&nbsp;({truncate(project.guild, 5)}|{truncate(project.location, 10)})
                             </a>
                         </h3>
                         <p className="text-light text-xs line-clamp-1">{project.notes}</p>

--- a/client/src/enums.ts
+++ b/client/src/enums.ts
@@ -9,7 +9,7 @@ export enum JudgeSortField {
 
 export enum ProjectSortField {
     Name,
-    Location,
+    GuildLocation,
     Score,
     Seen,
     Updated,

--- a/client/src/enums.ts
+++ b/client/src/enums.ts
@@ -1,6 +1,7 @@
 export enum JudgeSortField {
     Name,
     Email,
+    KeycloakUserId,
     Seen,
     BatchesSubmitted,
     Updated,

--- a/client/src/pages/Expo.tsx
+++ b/client/src/pages/Expo.tsx
@@ -30,7 +30,11 @@ const Expo = () => {
         if (nameSort) {
             sortedProjects.sort((a, b) => a.name.localeCompare(b.name));
         } else {
-            sortedProjects.sort((a, b) => a.location - b.location);
+            sortedProjects.sort((a, b) => {
+                let guildCompare = a.guild.localeCompare(b.guild);
+                if (guildCompare !== 0) return guildCompare;
+                return a.location.localeCompare(b.location);
+            });
         }
 
         setProjects(sortedProjects);
@@ -71,7 +75,7 @@ const Expo = () => {
                                     {truncate(project.name, 20)}
                                 </a>
                             </td>
-                            <td className="px-4 py-2">{project.location}</td>
+                            <td className="px-4 py-2">{project.guild}|{project.location}</td>
                         </tr>
                     ))}
                 </tbody>

--- a/client/src/pages/admin/settings.tsx
+++ b/client/src/pages/admin/settings.tsx
@@ -278,7 +278,7 @@ const AdminSettings = () => {
                 <Button
                     type="primary"
                     onClick={updateCategories}
-                    className="mt-4 w-auto md:w-auto px-4 py-2 mb-8"  // todo:  add white inner outline to buttons on focus?
+                    className="mt-4 w-auto md:w-auto px-4 py-2 mb-8"
                 >
                     Update Categories
                 </Button>

--- a/client/src/pages/admin/settings.tsx
+++ b/client/src/pages/admin/settings.tsx
@@ -278,7 +278,7 @@ const AdminSettings = () => {
                 <Button
                     type="primary"
                     onClick={updateCategories}
-                    className="mt-4 w-auto md:w-auto px-4 py-2 mb-8"  // lucatodo:  add white inner outline to buttons on focus?
+                    className="mt-4 w-auto md:w-auto px-4 py-2 mb-8"  // todo:  add white inner outline to buttons on focus?
                 >
                     Update Categories
                 </Button>

--- a/client/src/pages/judge/index.tsx
+++ b/client/src/pages/judge/index.tsx
@@ -176,7 +176,8 @@ const Judge = () => {
             return;
         }
 
-        alert('You can now take a break! Press "Next project" to continue judging.');
+        alert('Your current project was freed up for another judge. You can now take a break! ' +
+              'Just press "Next project" to continue judging.');
     };
 
     const handleDragStart = (event: DragStartEvent) => {

--- a/client/src/pages/judge/project.tsx
+++ b/client/src/pages/judge/project.tsx
@@ -66,7 +66,7 @@ const Project = () => {
                         {project.name}
                     </a>
                 </h1>
-                <h2 className="text-xl font-bold text-light mb-2">Location: {project.location}</h2>
+                <h2 className="text-xl font-bold text-light mb-2">Location: {project.guild}|{project.location}</h2>
                 <Ratings
                     prior={project.categories}
                     project={project}

--- a/client/src/store.tsx
+++ b/client/src/store.tsx
@@ -14,6 +14,7 @@ interface AdminStore {
 const useAdminStore = create<AdminStore>()((set) => ({
     stats: {
         projects: 0,
+        hidden_projects: 0,
         avg_project_seen: 0,
         avg_judge_seen: 0,
         judges: 0,

--- a/client/src/types.d.ts
+++ b/client/src/types.d.ts
@@ -31,6 +31,7 @@ interface Judge {
     name: string;
     code: string;
     email: string;
+    keycloak_user_id: string;
     notes: string;
     read_welcome: boolean;
     seen: number;

--- a/client/src/types.d.ts
+++ b/client/src/types.d.ts
@@ -1,6 +1,7 @@
 interface Project {
     id: string;
     name: string;
+    guild: string;
     location: string;
     description: string;
     url: string;
@@ -15,6 +16,7 @@ interface Project {
 
 interface PublicProject {
     name: string;
+    guild: string;
     location: number;
     description: string;
     url: string;
@@ -73,6 +75,7 @@ interface JudgedProject {
     categories: { [name: string]: number };
     notes: string;
     name: string;
+    guild: string;
     location: string;
     description: string;
 }

--- a/client/src/types.d.ts
+++ b/client/src/types.d.ts
@@ -26,7 +26,7 @@ interface PublicProject {
 }
 
 interface Judge {
-    // lucatodo: update this schema based on actual return and then update usages
+    // todo: update this schema based on actual return and then update usages
     id: string;
     name: string;
     code: string;

--- a/client/src/types.d.ts
+++ b/client/src/types.d.ts
@@ -44,6 +44,7 @@ interface Judge {
 
 interface Stats {
     projects: number;
+    hidden_projects: number;
     avg_project_seen: number;
     avg_judge_seen: number;
     judges: number;

--- a/client/src/types.d.ts
+++ b/client/src/types.d.ts
@@ -17,7 +17,7 @@ interface Project {
 interface PublicProject {
     name: string;
     guild: string;
-    location: number;
+    location: string;
     description: string;
     url: string;
     try_link: string;

--- a/client/src/util.tsx
+++ b/client/src/util.tsx
@@ -65,7 +65,7 @@ function errorAlert<T>(res: FetchResponse<T>) {
 // adding a dot at the end if the length is > than width chars
 function truncate(s: string, width: number = 8) {
     if (s.length <= width) return s;
-    return s.substring(0, width-1) + '.';
+    return s.substring(0, width-2) + '..';
 }
 
 export { timeSince, arrow, fixIfFloat, fixIfFloatDigits, errorAlert, showTopFive, truncate };

--- a/server/config/values.go
+++ b/server/config/values.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+
 	"github.com/joho/godotenv"
 )
 
@@ -28,7 +29,7 @@ func init() {
 	ApiOrigin = GetOptEnv("API_ORIGIN", "http://jury.durhack-dev.com")
 	KeycloakRealm = GetOptEnv("KEYCLOAK_REALM", "durhack-dev")
 	KeycloakBaseUrl = GetOptEnv("KEYCLOAK_BASE_URL", "https://auth.durhack.com")
-	// lucatodo: accomodate additional realm structure (i.e. admin) to get user names without hard saving in Flag db etc.
+	// durhacktodo: accomodate additional realm structure (i.e. admin) to get user names without hard saving in Flag db etc.
 	// https://github.com/ducompsoc/durhack/blob/130a71ab674288cbe1a6e0e2f3a518773658bc9f/server/src/config/default.ts#L22C3-L30C5
 	KeycloakAdminBaseUrl = GetOptEnv("KEYCLOAK_ADMIN_BASE_URL", "https://admin.auth.durhack.com")
 	ClientID = GetEnv("KEYCLOAK_OAUTH2_CLIENT_ID")

--- a/server/database/admin.go
+++ b/server/database/admin.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"context"
+
 	"server/models"
 
 	"github.com/gin-gonic/gin"
@@ -26,7 +27,7 @@ func AggregateStats(db *mongo.Database) (*models.Stats, error) {
 
 	// Get the average project seen using an aggregation pipeline
 	projCursor, err := db.Collection("projects").Aggregate(context.Background(), []gin.H{
-		{"$match": gin.H{"active": true}},
+		// {"$match": gin.H{"active": true}},
 		{"$group": gin.H{
 			"_id": nil,
 			"avgSeen": gin.H{
@@ -49,6 +50,11 @@ func AggregateStats(db *mongo.Database) (*models.Stats, error) {
 		} else {
 			return nil, err
 		}
+	}
+
+	numHiddenProjects, err := db.Collection("projects").CountDocuments(context.Background(), gin.H{"active": false})
+	if err != nil {
+		return nil, err
 	}
 
 	// Get the average judge seen using an aggregation pipeline
@@ -82,6 +88,7 @@ func AggregateStats(db *mongo.Database) (*models.Stats, error) {
 
 	// Set stats from aggregations
 	stats.Projects = totalProjects
+	stats.HiddenProjects = numHiddenProjects
 	stats.Judges = totalJudges
 	stats.AvgProjectSeen = projAvgSeen.AvgSeen
 	stats.AvgJudgeSeen = judgeAvgSeen.AvgSeen

--- a/server/database/judge.go
+++ b/server/database/judge.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"context"
+
 	mongoOptions "go.mongodb.org/mongo-driver/mongo/options"
 	"server/models"
 	"server/util"
@@ -98,7 +99,7 @@ func AggregateJudgeStats(db *mongo.Database) (*models.JudgeStats, error) {
 	return &stats, nil
 }
 
-// lucatodo: implement API on Jury to allow keycloak client to delete a judge 'remotely'
+// durhacktodo: implement API on Jury to allow keycloak client to delete a judge 'remotely'
 // DeleteJudgeById deletes a judge from the database by their id
 func DeleteJudgeById(db *mongo.Database, id primitive.ObjectID) error {
 	_, err := db.Collection("judges").DeleteOne(context.Background(), gin.H{"_id": id})

--- a/server/database/project.go
+++ b/server/database/project.go
@@ -189,7 +189,15 @@ func CountProjectDocuments(db *mongo.Database) (int64, error) {
 
 // SetProjectHidden sets the active field of a project
 func SetProjectHidden(db *mongo.Database, id *primitive.ObjectID, hidden bool) error {
-	_, err := db.Collection("projects").UpdateOne(context.Background(), gin.H{"_id": id}, gin.H{"$set": gin.H{"active": !hidden}})
+	_, err := db.Collection("projects").UpdateOne(
+		context.Background(), gin.H{"_id": id}, gin.H{"$set": gin.H{"active": !hidden}})
+	return err
+}
+
+// SetProjectsHidden sets the active fields of many projects in bulk
+func SetProjectsHidden(db *mongo.Database, ids *[]primitive.ObjectID, hidden bool) error {
+	_, err := db.Collection("projects").UpdateMany(
+		context.Background(), gin.H{"_id": gin.H{"$in": ids}}, gin.H{"$set": gin.H{"active": !hidden}})
 	return err
 }
 

--- a/server/funcs/csv.go
+++ b/server/funcs/csv.go
@@ -177,7 +177,7 @@ func AddZipFile(name string, content []byte, ctx *gin.Context) {
 	ctx.Data(http.StatusOK, "application/octet-stream", content)
 }
 
-// Create a CSV file from the judges but only the rankings  lucatodo: update for new ranking object structures (2D array)
+// Create a CSV file from the judges but only the rankings
 func CreateJudgeRankingCSV(judges []*models.Judge) []byte {
 	csvBuffer := &bytes.Buffer{}
 
@@ -185,7 +185,7 @@ func CreateJudgeRankingCSV(judges []*models.Judge) []byte {
 	w := csv.NewWriter(csvBuffer)
 
 	// Write the header
-	// lucatodo: remove unranked concept
+	// todo: remove unranked concept
 	w.Write([]string{"Name", "Code", "Ranked", "Unranked"})
 
 	// Write each judge
@@ -196,7 +196,7 @@ func CreateJudgeRankingCSV(judges []*models.Judge) []byte {
 		}
 
 		// Create a list of all ranked projects (just their location)
-		ranked := make([]string, 0, len(judge.CurrentRankings))
+		ranked := make([]string, 0, len(judge.CurrentRankings)) // todo: update for new ranking object structures (2D array)
 		for _, projId := range judge.CurrentRankings {
 			idx := util.IndexFunc(judge.SeenProjects, func(p models.JudgedProject) bool {
 				return p.ProjectId == projId
@@ -217,7 +217,7 @@ func CreateJudgeRankingCSV(judges []*models.Judge) []byte {
 		}
 
 		// Write line to CSV
-		// lucatodo: get judge info (from gocloak using admin api) to write to csv
+		// durhacktodo: get judge info (from gocloak using admin api) to write to csv
 		w.Write([]string{judge.KeycloakUserId, strings.Join(ranked, ","), strings.Join(unranked, ",")})
 	}
 

--- a/server/funcs/csv.go
+++ b/server/funcs/csv.go
@@ -245,7 +245,7 @@ func CreateProjectCSV(projects []*models.Project, scores []ranking.RankedObject)
 
 	// Write each project
 	for _, project := range projects {
-		w.Write([]string{project.Name, project.Location, project.Description, project.Url, project.TryLink,
+		w.Write([]string{project.Name, project.GetLocationString(), project.Description, project.Url, project.TryLink,
 			project.VideoLink, strings.Join(project.ChallengeList, ","), fmt.Sprintf("%d", project.Seen),
 			fmt.Sprintf("%t", project.Active), fmt.Sprintf("%d", project.LastActivity),
 			fmt.Sprintf("%.1f", scoreMap[project.Id])})

--- a/server/judging/judging_flow.go
+++ b/server/judging/judging_flow.go
@@ -3,10 +3,11 @@ package judging
 import (
 	"errors"
 	"math/rand"
+	"slices"
+
 	"server/database"
 	"server/models"
 	"server/util"
-	"slices"
 
 	"github.com/gin-gonic/gin"
 	"go.mongodb.org/mongo-driver/mongo"
@@ -65,6 +66,9 @@ func SkipCurrentProject(db *mongo.Database, judge *models.Judge, judgeName strin
 			return nil, err
 		}
 
+		if project == nil { // Handle no projects left to get
+			return nil, nil
+		}
 		// Update the judge
 		return database.UpdateAfterPickedWithTx(db, project, judge, ctx)
 	})

--- a/server/judging/judging_flow.go
+++ b/server/judging/judging_flow.go
@@ -130,7 +130,7 @@ func PickNextProject(db *mongo.Database, judge *models.Judge, ctx mongo.SessionC
 //  2. Filter out all projects that the judge has already seen
 //  3. Filter out all projects that the judge has flagged (except for busy projects)
 //  4. Filter out projects that are currently being judged (if no projects remain after filter, ignore step)
-//  5. Filter out all projects that have less than the minimum number of views (if no projects remain after filter, ignore step)
+//  5. Filter out all projects that have more than the current smallest number of views (if no projects remain after filter, ignore step)
 func FindPreferredItems(db *mongo.Database, judge *models.Judge, ctx mongo.SessionContext) ([]*models.Project, error) {
 	// TODO: Ensure judge does not get the project they _just_ skipped -- ideally we would keep a list of projects that the judge has skipped and clear it when the judge finds a project they don't skip (after voting)
 
@@ -200,7 +200,7 @@ func FindPreferredItems(db *mongo.Database, judge *models.Judge, ctx mongo.Sessi
 		projects = freeProjects
 	}
 
-	// Get the minimum number of views of the remaining projects
+	// Get the current smallest number of views of the remaining projects
 	minSeen := projects[0].Seen
 	for _, proj := range projects {
 		if proj.Seen < minSeen {
@@ -208,7 +208,7 @@ func FindPreferredItems(db *mongo.Database, judge *models.Judge, ctx mongo.Sessi
 		}
 	}
 
-	// Filter out projects that have more than the minimum number of views
+	// Filter out projects that have more than the current smallest number of views
 	var minViewProjects []*models.Project
 	for _, proj := range projects {
 		if proj.Seen == minSeen {

--- a/server/models/flag.go
+++ b/server/models/flag.go
@@ -52,7 +52,7 @@ func NewFlag(project *Project, judge *Judge, judgeName string, reason string) (*
 		JudgeId:         &judge.Id,
 		Time:            primitive.NewDateTimeFromTime(time.Now()),
 		ProjectName:     project.Name,
-		ProjectLocation: project.Location,
+		ProjectLocation: project.GetLocationString(),
 		JudgeName:       judgeName,
 		Reason:          reason,
 	}, nil

--- a/server/models/judge.go
+++ b/server/models/judge.go
@@ -24,8 +24,13 @@ type JudgedProject struct {
 	Categories  map[string]int     `bson:"categories" json:"categories"`
 	Notes       string             `bson:"notes" json:"notes"`
 	Name        string             `bson:"name" json:"name"`
+	Guild       string             `bson:"guild" json:"guild"`
 	Location    string             `bson:"location" json:"location"`
 	Description string             `bson:"description" json:"description"`
+}
+
+func (jp *JudgedProject) GetLocationString() string {
+	return jp.Guild + "|" + jp.Location
 }
 
 func NewJudge(keycloakUserId string) *Judge {
@@ -48,6 +53,7 @@ func JudgeProjectFromProject(project *Project, categories map[string]int) *Judge
 		ProjectId:   project.Id,
 		Categories:  categories,
 		Name:        project.Name,
+		Guild:       project.Guild,
 		Location:    project.Location,
 		Description: project.Description,
 		Notes:       "",

--- a/server/models/project.go
+++ b/server/models/project.go
@@ -22,7 +22,11 @@ type Project struct {
 }
 
 func (p *Project) GetLocationString() string {
-	return p.Guild + "|" + p.Location
+	if p.Guild == "" {
+		return p.Location
+	} else {
+		return p.Guild + "|" + p.Location
+	}
 }
 
 func NewProject(name string, guild string, location string, description string, url string, tryLink string, videoLink string, challengeList []string) *Project {

--- a/server/models/project.go
+++ b/server/models/project.go
@@ -9,6 +9,7 @@ import (
 type Project struct {
 	Id            primitive.ObjectID `bson:"_id,omitempty" json:"id"`
 	Name          string             `bson:"name" json:"name"`
+	Guild         string             `bson:"guild" json:"guild"`
 	Location      string             `bson:"location" json:"location"`
 	Description   string             `bson:"description" json:"description"`
 	Url           string             `bson:"url" json:"url"`
@@ -20,9 +21,14 @@ type Project struct {
 	LastActivity  primitive.DateTime `bson:"last_activity" json:"last_activity"`
 }
 
-func NewProject(name string, location string, description string, url string, tryLink string, videoLink string, challengeList []string) *Project {
+func (p *Project) GetLocationString() string {
+	return p.Guild + "|" + p.Location
+}
+
+func NewProject(name string, guild string, location string, description string, url string, tryLink string, videoLink string, challengeList []string) *Project {
 	return &Project{
 		Name:          name,
+		Guild:         guild,
 		Location:      location,
 		Description:   description,
 		Url:           url,

--- a/server/models/types.go
+++ b/server/models/types.go
@@ -14,6 +14,7 @@ type ProjectStats struct {
 
 type Stats struct {
 	Projects       int64   `json:"projects"`
+	HiddenProjects int64   `json:"hidden_projects"`
 	Judges         int64   `json:"judges"`
 	AvgProjectSeen float64 `json:"avg_project_seen"`
 	AvgJudgeSeen   float64 `json:"avg_judge_seen"`

--- a/server/models/types.go
+++ b/server/models/types.go
@@ -27,6 +27,11 @@ type IdRequest struct {
 	Id string `json:"id"`
 }
 
+type MultiIdHideRequest struct {
+	Ids  []string `json:"ids"`
+	Hide bool     `json:"hide"`
+}
+
 type ProjectLocationRequest struct {
 	IdRequest
 	Location string `json:"location"`

--- a/server/router/auth.go
+++ b/server/router/auth.go
@@ -3,16 +3,17 @@ package router
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"net/url"
+	"slices"
+
 	"github.com/gin-contrib/sessions"
 	"github.com/gin-gonic/gin"
 	"go.mongodb.org/mongo-driver/mongo"
 	mongoOptions "go.mongodb.org/mongo-driver/mongo/options"
 	"golang.org/x/oauth2"
-	"net/http"
-	"net/url"
 	"server/auth"
 	"server/config"
-	"slices"
 )
 
 func getOrGenerateCodeVerifier(ctx *gin.Context) (string, error) {
@@ -110,7 +111,7 @@ func KeycloakOAuth2FlowCallback() gin.HandlerFunc {
 			mongoOptions.Update().SetUpsert(true),
 		)
 
-		if err != nil { // lucatodo: proper error handling of database errors (fmt.Println -> logging in middleware)
+		if err != nil {
 			_ = ctx.AbortWithError(http.StatusInternalServerError, err)
 			fmt.Println(err.Error())
 			return

--- a/server/router/init.go
+++ b/server/router/init.go
@@ -118,6 +118,7 @@ func NewRouter(db *mongo.Database) *gin.Engine {
 	adminRouter.POST("/judge/hide", HideJudge)
 	adminRouter.POST("/judge/unhide", UnhideJudge)
 	adminRouter.POST("/project/hide", HideProject)
+	adminRouter.POST("/project/hide-unhide-many", HideUnhideManyProjects)
 	adminRouter.POST("/project/unhide", UnhideProject)
 	adminRouter.POST("/project/prioritize", PrioritizeProject)
 	adminRouter.POST("/project/unprioritize", UnprioritizeProject)

--- a/server/router/init.go
+++ b/server/router/init.go
@@ -3,6 +3,7 @@ package router
 import (
 	"log"
 	"net/url"
+
 	"server/config"
 	"server/database"
 	"server/judging"
@@ -67,13 +68,14 @@ func NewRouter(db *mongo.Database) *gin.Engine {
 	router.Use(sessions.Sessions("durhack-jury-session", store))
 
 	// Create router groups for judge and admins
-	// lucatodo: document routing behaviour r.e. login and auth
+	// todo: document routing behaviour r.e. login and auth
 	authenticatedRouter := router.Group("", Authenticate())
 	judgeRouter := authenticatedRouter.Group("/api", AuthoriseJudge())
 	adminRouter := authenticatedRouter.Group("/api", AuthoriseAdmin())
 	defaultRouter := router.Group("/api")
 
-	// lucatodo: improved error handling middleware: https://stackoverflow.com/questions/69948784/how-to-handle-errors-in-gin-middleware/69948929#69948929
+	// todo: improved error handling middleware: https://stackoverflow.com/questions/69948784/how-to-handle-errors-in-gin-middleware/69948929#69948929
+	// also todo: proper error handling of database errors (instead of fmt.Println -> logging in middleware)
 	// Authenticated login routes
 	defaultRouter.GET("/auth/keycloak/login", BeginKeycloakOAuth2Flow())
 	defaultRouter.GET("/auth/keycloak/callback", KeycloakOAuth2FlowCallback(), HandleLoginSuccess())

--- a/server/router/judge.go
+++ b/server/router/judge.go
@@ -207,6 +207,7 @@ func addUrlToJudgedProject(project *models.JudgedProject, url string) *JudgedPro
 			ProjectId:   project.ProjectId,
 			Categories:  project.Categories,
 			Name:        project.Name,
+			Guild:       project.Guild,
 			Location:    project.Location,
 			Description: project.Description,
 			Notes:       project.Notes,

--- a/server/router/project.go
+++ b/server/router/project.go
@@ -2,10 +2,11 @@ package router
 
 import (
 	"net/http"
+	"strings"
+
 	"server/database"
 	"server/funcs"
 	"server/models"
-	"strings"
 
 	"github.com/gin-gonic/gin"
 	"go.mongodb.org/mongo-driver/bson/primitive"
@@ -132,6 +133,7 @@ func ListProjects(ctx *gin.Context) {
 
 type PublicProject struct {
 	Name          string `json:"name"`
+	Guild         string `json:"guild"`
 	Location      string `json:"location"`
 	Description   string `json:"description"`
 	Url           string `json:"url"`
@@ -156,6 +158,7 @@ func ListPublicProjects(ctx *gin.Context) {
 	for i, project := range projects {
 		publicProjects[i] = PublicProject{
 			Name:          project.Name,
+			Guild:         project.Guild,
 			Location:      project.Location,
 			Description:   project.Description,
 			Url:           project.Url,

--- a/server/router/project.go
+++ b/server/router/project.go
@@ -59,6 +59,7 @@ func AddDevpostCsv(ctx *gin.Context) {
 
 type AddProjectRequest struct {
 	Name          string `json:"name"`
+	Guild         string `json:"guild"`
 	Location      string `json:"location"`
 	Description   string `json:"description"`
 	Url           string `json:"url"`
@@ -96,7 +97,7 @@ func AddProject(ctx *gin.Context) {
 	}
 
 	// Create the project
-	project := models.NewProject(projectReq.Name, projectReq.Location, projectReq.Description, projectReq.Url, projectReq.TryLink, projectReq.VideoLink, challengeList)
+	project := models.NewProject(projectReq.Name, projectReq.Guild, projectReq.Location, projectReq.Description, projectReq.Url, projectReq.TryLink, projectReq.VideoLink, challengeList)
 
 	// Insert project and update the next table num field in options
 	err = database.WithTransaction(db, func(ctx mongo.SessionContext) (interface{}, error) {


### PR DESCRIPTION
### Description

This PR adds the **ability to hide projects in bulk** (including by guild) by selecting lots of them as seen in the screenshot below:
![{1B9FB911-ECBE-40BC-98A5-A13981896948}](https://github.com/user-attachments/assets/cbfc7954-3871-4ff2-b7df-9ec1e2c4c197)
This closes #3 🥳

The above also involved allowing the guild field of the projects to be specified (now separate from location - this is still a string though).

This PR also includes a bunch of UI tweaks to make the admin and judging process better. Lots of wording is also clarified throughout the UI.

